### PR TITLE
Support float8 dtype

### DIFF
--- a/py/runai_model_streamer/requirements.dev
+++ b/py/runai_model_streamer/requirements.dev
@@ -1,4 +1,4 @@
-torch>=2.0.0,<3.0.0
+torch>=2.1.0,<3.0.0
 numpy==1.24.4
 safetensors==0.4.2
 humanize==4.9.0

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_pytorch.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_pytorch.py
@@ -25,6 +25,8 @@ safetenors_to_torch_dtype = {
     "I8": torch.int8,
     "U8": torch.uint8,
     "BOOL": torch.bool,
+    "F8_E5M2": torch.float8_e5m2,
+    "F8_E4M3": torch.float8_e4m3fn,
 }
 
 


### PR DESCRIPTION
In this PR we introduce support in float8 data types.

When a `.safetensors` file is read and contains a tensor in `F8_E5M2` \ `F8_E4M3` dtype, we currently dont have a translation to which data type is in PyTorch, thus throwing exception that there is a type we do not support.

In this PR we add this translation, thus add support for float8 types