### PR TITLE
fix race when shutting down the streamer

### DIFF
--- a/cpp/common/responder/responder.h
+++ b/cpp/common/responder/responder.h
@@ -58,6 +58,8 @@ struct Responder
 
     std::atomic<size_t> _total_bytesize;
     std::chrono::time_point<std::chrono::steady_clock> _start_time;
+
+    bool _successful = true;
 };
 
 }; // namespace runai::llm::streamer::common

--- a/cpp/utils/threadpool/threadpool.h
+++ b/cpp/utils/threadpool/threadpool.h
@@ -21,7 +21,7 @@ struct Deque
         {
             const auto lock = std::unique_lock<std::mutex>(_mutex);
 
-            ASSERT(!_stopped) << "Pusing a message to an already stopped queue";
+            ASSERT(!_stopped) << "Pushing a message to an already stopped queue";
 
             _deque.push_back(std::move(message));
         }
@@ -52,8 +52,10 @@ struct Deque
         {
             const auto lock = std::unique_lock<std::mutex>(_mutex);
 
-            CHECK(_deque.size() == 0) << "Stopping a `Deque` with unresolved messages";
-
+            if (_deque.size() != 0)
+            {
+                LOG(DEBUG) << "Stopping a `Deque` with unresolved messages";
+            }
             _stopped = true;
         }
 


### PR DESCRIPTION
When the streamer is closed soon after initialized, there is a race condition that caused the application to hang.
This was the result of the `Responder` waiting for all responses, although not all the requests were actually sent.

In addition, I fixed the log of the throughput to be logged only for successful reads of more than 100 MB