### PR TITLE
set default concurrency level to 16

### DIFF
--- a/cpp/streamer/impl/config/config.cc
+++ b/cpp/streamer/impl/config/config.cc
@@ -34,7 +34,7 @@ Config::Config(unsigned concurrency, size_t s3_block_bytesize, size_t fs_block_b
 }
 
 Config::Config(bool enforce_minimum /* = true */) :
-    Config(utils::getenv<unsigned long>("RUNAI_STREAMER_CONCURRENCY", 20UL),
+    Config(utils::getenv<unsigned long>("RUNAI_STREAMER_CONCURRENCY", 16UL),
            utils::getenv<size_t>("RUNAI_STREAMER_CHUNK_BYTESIZE", common::s3::S3ClientWrapper::default_chunk_bytesize),
            utils::getenv<size_t>("RUNAI_STREAMER_CHUNK_BYTESIZE", min_fs_block_bytesize), enforce_minimum)
 {}

--- a/cpp/streamer/impl/config/config_test.cc
+++ b/cpp/streamer/impl/config/config_test.cc
@@ -14,7 +14,7 @@ namespace runai::llm::streamer::impl
 TEST(Creation, Default)
 {
     Config config;
-    EXPECT_EQ(config.concurrency, 20UL);
+    EXPECT_EQ(config.concurrency, 16UL);
     EXPECT_EQ(config.s3_block_bytesize, 8 * 1024 * 1024);
     EXPECT_EQ(config.fs_block_bytesize, 2 * 1024 * 1024);
 }
@@ -38,7 +38,7 @@ TEST(Creation, Chunk_Size)
         utils::temp::Env size_("RUNAI_STREAMER_CHUNK_BYTESIZE", expected);
         Config config;
 
-        EXPECT_EQ(config.concurrency, 20UL);
+        EXPECT_EQ(config.concurrency, 16UL);
         EXPECT_EQ(config.s3_block_bytesize, std::max(expected, min_));
         EXPECT_EQ(config.fs_block_bytesize, std::max(expected, Config::min_fs_block_bytesize));
     }


### PR DESCRIPTION
Default concurrency level was set to 16. 

When reading from S3 or S3 compatible, each thread creates its own Aws S3CrtClient. For the default file descriptors limit which is 1024, the maximal number of S3CrtClient objects that can be created is 16.
For higher concurrency level, the user should also increase the file descriptors limit on the host (e.g. `ulimit -n 4096`)

It should be noted that each S3CrtClient by itself handles several requests concurrently (Aws default is 50)