### PR TITLE
Cancelling on going request when shutting down the streamer

### DIFF
--- a/cpp/common/responder/BUILD
+++ b/cpp/common/responder/BUILD
@@ -14,6 +14,7 @@ runai_cc_test(
     srcs = ["responder_test.cc"],
     deps = [":responder",
             "//utils/threadpool",
+            "//utils/thread",
             "//utils/random",
     ],
 )

--- a/cpp/common/responder/responder.cc
+++ b/cpp/common/responder/responder.cc
@@ -100,16 +100,11 @@ void Responder::cancel()
 void Responder::stop()
 {
     {
-        LOG(DEBUG) << "stopping responder";
         const auto guard = std::unique_lock<std::mutex>(_mutex);
         _stopped = true;
-        LOG(DEBUG) << "stopped responder";
     }
     // wake up blocking waiting threads
     _ready.post();
-    LOG(DEBUG) << "notified stopped responder";
-
-
 }
 
 size_t Responder::bytes_per_second() const

--- a/cpp/common/responder/responder.cc
+++ b/cpp/common/responder/responder.cc
@@ -25,15 +25,21 @@ Responder::~Responder()
 // return -1 if there are no running requests
 Response Responder::pop()
 {
-    if (finished())
+    if (_stopped || finished())
     {
-        LOG(DEBUG) << "responder does not expect any more responses";
+        LOG(DEBUG) << (_stopped ? "responder does not expect any more responses" : "responder stopped");
         return ResponseCode::FinishedError;
     }
 
     _ready.wait();
 
     const auto guard = std::unique_lock<std::mutex>(_mutex);
+
+    if (_stopped)
+    {
+        LOG(DEBUG) << "responder stopped";
+        return ResponseCode::FinishedError;
+    }
 
     ASSERT(!_responses.empty()) << "responder is empty after notification. Current running " << _running;
 
@@ -89,6 +95,21 @@ void Responder::cancel()
 {
     const auto guard = std::unique_lock<std::mutex>(_mutex);
     _canceled = true;
+}
+
+void Responder::stop()
+{
+    {
+        LOG(DEBUG) << "stopping responder";
+        const auto guard = std::unique_lock<std::mutex>(_mutex);
+        _stopped = true;
+        LOG(DEBUG) << "stopped responder";
+    }
+    // wake up blocking waiting threads
+    _ready.post();
+    LOG(DEBUG) << "notified stopped responder";
+
+
 }
 
 size_t Responder::bytes_per_second() const

--- a/cpp/common/responder/responder.cc
+++ b/cpp/common/responder/responder.cc
@@ -11,6 +11,7 @@ namespace runai::llm::streamer::common
 Responder::Responder(unsigned running) :
     _running(running),
     _ready(0),
+    _stopped(false),
     _total_bytesize(0),
     _start_time(std::chrono::steady_clock::now())
 {
@@ -54,6 +55,12 @@ void Responder::push(Response && response)
 {
     {
         const auto guard = std::unique_lock<std::mutex>(_mutex);
+
+        if (_stopped)
+        {
+            // ignore responses
+            return;
+        }
 
         _successful  = _successful && response.ret == common::ResponseCode::Success;
 

--- a/cpp/common/responder/responder.h
+++ b/cpp/common/responder/responder.h
@@ -35,6 +35,7 @@ struct Responder
     void push(Response && response, size_t bytesize);
 
     void cancel();
+    void stop();
 
     bool finished() const;
 
@@ -55,6 +56,7 @@ struct Responder
     mutable std::mutex _mutex;
 
     bool _canceled = false;
+    bool _stopped = false;
 
     std::atomic<size_t> _total_bytesize;
     std::chrono::time_point<std::chrono::steady_clock> _start_time;

--- a/cpp/common/responder/responder.h
+++ b/cpp/common/responder/responder.h
@@ -56,7 +56,7 @@ struct Responder
     mutable std::mutex _mutex;
 
     bool _canceled = false;
-    bool _stopped = false;
+    std::atomic<bool> _stopped;
 
     std::atomic<size_t> _total_bytesize;
     std::chrono::time_point<std::chrono::steady_clock> _start_time;

--- a/cpp/common/responder/responder_test.cc
+++ b/cpp/common/responder/responder_test.cc
@@ -67,7 +67,7 @@ TEST(Pop, Wait)
     auto responder = Responder(size);
 
     // create threadpool to push
-    auto pool = utils::ThreadPool<unsigned>([&](unsigned i)
+    auto pool = utils::ThreadPool<unsigned>([&](unsigned i, std::atomic<bool> &)
     {
         responder.push(i);
     }, size);
@@ -111,7 +111,7 @@ TEST(Pop, Error)
         auto responder = Responder(size);
 
         // create threadpool to push
-        auto pool = utils::ThreadPool<int>([&](int i)
+        auto pool = utils::ThreadPool<int>([&](int i, std::atomic<bool> &)
         {
             auto r = Response(rc);
             responder.push(std::move(r));
@@ -150,7 +150,7 @@ TEST(Pop, Unexpected_Responses)
 
     std::atomic<unsigned> completed = 0;
     auto finished = utils::Semaphore(0);
-    auto pool = utils::ThreadPool<unsigned>([&](unsigned i)
+    auto pool = utils::ThreadPool<unsigned>([&](unsigned i, std::atomic<bool> &)
     {
         responder.push(i);
         completed++;

--- a/cpp/common/s3_wrapper/s3_wrapper.cc
+++ b/cpp/common/s3_wrapper/s3_wrapper.cc
@@ -24,6 +24,19 @@ void S3ClientWrapper::shutdown()
     }
 }
 
+void S3ClientWrapper::stop()
+{
+    try
+    {
+        std::shared_ptr<utils::Dylib> s3_dylib(open_s3());
+        static auto __stop_s3_clients = s3_dylib->dlsym<void(*)()>("runai_stop_s3_clients");
+        __stop_s3_clients();
+    }
+    catch(...)
+    {
+    }
+}
+
 S3ClientWrapper::S3ClientWrapper(const StorageUri & uri) :
     _s3_dylib(open_s3()),
     _s3_client(create_client(uri))

--- a/cpp/common/s3_wrapper/s3_wrapper.h
+++ b/cpp/common/s3_wrapper/s3_wrapper.h
@@ -27,6 +27,11 @@ struct S3ClientWrapper
     ResponseCode async_read(std::vector<Range>& ranges, size_t chunk_bytesize, char * buffer);
     Response async_read_response();
 
+    // stop - stops the responder of each S3 client, in order to notify callers which sent a request and are waiting for a response
+    //        required for stopping the threadpool workers, which are bloking on the client responder
+    static void stop();
+
+    // destroy S3 all clients
     static void shutdown();
 
     static constexpr size_t min_chunk_bytesize = 5 * 1024 * 1024;

--- a/cpp/s3/client/client.cc
+++ b/cpp/s3/client/client.cc
@@ -14,6 +14,7 @@ namespace runai::llm::streamer::impl::s3
 {
 
 S3Client::S3Client(const common::s3::StorageUri & uri) :
+    _stop(false),
     _bucket_name(uri.bucket.c_str(), uri.bucket.size()),
     _path(uri.path.c_str(), uri.path.size())
 {
@@ -90,7 +91,7 @@ common::ResponseCode S3Client::async_read(unsigned num_ranges, common::Range * r
 
     char * buffer_ = buffer;
     common::Range * ranges_ = ranges;
-    for (unsigned ir = 0; ir < num_ranges; ++ir)
+    for (unsigned ir = 0; ir < num_ranges && !_stop; ++ir)
     {
         const auto & range_ = *ranges_;
 
@@ -106,7 +107,7 @@ common::ResponseCode S3Client::async_read(unsigned num_ranges, common::Range * r
 
         size_t total_ = range_.size;
         size_t offset_ = range_.start;
-        for (unsigned i = 0; i < size; ++i)
+        for (unsigned i = 0; i < size && !_stop; ++i)
         {
             size_t bytesize_ = (i == size - 1 ? total_ : chunk_bytesize);
 
@@ -164,7 +165,7 @@ common::ResponseCode S3Client::async_read(unsigned num_ranges, common::Range * r
         ranges_++;
     }
 
-    return common::ResponseCode::Success;
+    return _stop ? common::ResponseCode::FinishedError : common::ResponseCode::Success;
 }
 
 std::string S3Client::bucket() const
@@ -175,6 +176,12 @@ std::string S3Client::bucket() const
 void S3Client::path(const std::string & path)
 {
     _path = Aws::String(path.c_str(), path.size());
+}
+
+void S3Client::stop()
+{
+    _stop = true;
+    _responder->stop();
 }
 
 }; // namespace runai::llm::streamer::impl::s3

--- a/cpp/s3/client/client.cc
+++ b/cpp/s3/client/client.cc
@@ -85,6 +85,7 @@ common::ResponseCode S3Client::async_read(unsigned num_ranges, common::Range * r
     }
 
     _responder = std::make_shared<common::Responder>(num_ranges);
+
     Aws::S3Crt::Model::GetObjectRequest request;
     request.SetBucket(_bucket_name);
     request.SetKey(_path);
@@ -181,7 +182,10 @@ void S3Client::path(const std::string & path)
 void S3Client::stop()
 {
     _stop = true;
-    _responder->stop();
+    if (_responder != nullptr)
+    {
+        _responder->stop();
+    }
 }
 
 }; // namespace runai::llm::streamer::impl::s3

--- a/cpp/s3/client/client.h
+++ b/cpp/s3/client/client.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <string>
 
@@ -23,11 +24,17 @@ struct S3Client
 
     common::Response async_read_response();
 
+    // Stop sending requests to the object store
+    // Requests that were already sent cannot be cancelled, since the Aws S3CrtClient does not support aborting requests
+    // The S3CrtClient d'tor will wait for response of all teh sent requests, which can take a while
+    void stop();
+
     std::string bucket() const;
 
     void path(const std::string & path);
 
  private:
+    std::atomic<bool> _stop;
     ClientConfiguration _client_config;
     std::unique_ptr<Aws::S3Crt::S3CrtClient> _client;
     const Aws::String _bucket_name;

--- a/cpp/s3/client_mgr/client_mgr.h
+++ b/cpp/s3/client_mgr/client_mgr.h
@@ -29,6 +29,9 @@ struct ClientMgr
 
     static void clear();
 
+    // stop all clients
+    static void stop();
+
     // for testing:
     static unsigned size();
     static unsigned unused();
@@ -170,6 +173,20 @@ void ClientMgr<T>::clear()
     mgr._clients.clear();
     mgr._bucket_unused_clients.clear();
     mgr._current_bucket.clear();
+}
+
+template <typename T>
+void ClientMgr<T>::stop()
+{
+    LOG(DEBUG) << "Stopping all S3 clients";
+    auto & mgr = get();
+
+    const auto guard = std::unique_lock<std::mutex>(mgr._mutex);
+
+    for (auto & pair : mgr._clients)
+    {
+        pair.second->stop();
+    }
 }
 
 using S3ClientMgr = ClientMgr<S3Client>;

--- a/cpp/s3/s3.cc
+++ b/cpp/s3/s3.cc
@@ -58,6 +58,18 @@ void runai_release_s3_clients()
     }
 }
 
+void runai_stop_s3_clients()
+{
+    try
+    {
+        S3ClientMgr::stop();
+    }
+    catch(const std::exception & e)
+    {
+        LOG(ERROR) << "Failed to stop all S3 clients";
+    }
+}
+
 common::ResponseCode  runai_async_read_s3_client(void * client, unsigned num_ranges, common::Range * ranges, size_t chunk_bytesize, char * buffer)
 {
     try

--- a/cpp/s3/s3.h
+++ b/cpp/s3/s3.h
@@ -37,6 +37,9 @@ extern "C" void runai_remove_s3_client(void * client);
 extern "C" common::ResponseCode  runai_async_read_s3_client(void * client, unsigned num_ranges, common::Range * ranges, size_t chunk_bytesize, char * buffer);
 // wait for asynchronous read response
 extern "C" common::ResponseCode  runai_async_response_s3_client(void * client, unsigned * index /* output parameter */);
+// stop clients
+// Stops the responder of each client, in order to notify callers which sent a request and are waiting for a response
+extern "C" void runai_stop_s3_clients();
 // release clients
 extern "C" void runai_release_s3_clients();
 

--- a/cpp/s3/s3.ldscript
+++ b/cpp/s3/s3.ldscript
@@ -4,6 +4,7 @@
         runai_remove_s3_client;
         runai_async_read_s3_client;
         runai_async_response_s3_client;
+        runai_stop_s3_clients;
         runai_release_s3_clients;
     local: *;
 };

--- a/cpp/s3/s3_mock/s3_mock.h
+++ b/cpp/s3/s3_mock/s3_mock.h
@@ -13,6 +13,7 @@ extern "C" common::ResponseCode  runai_async_read_s3_client(void * client, unsig
 extern "C" common::ResponseCode  runai_async_response_s3_client(void * client, unsigned * index /* output parameter */);
 extern "C" void runai_release_s3_clients();
 
+extern "C" void runai_mock_s3_set_response_time_ms(unsigned milliseconds);
 extern "C" int runai_mock_s3_clients();
 
 }; //namespace runai::llm::streamer::common::s3

--- a/cpp/s3/s3_mock/s3_mock.h
+++ b/cpp/s3/s3_mock/s3_mock.h
@@ -11,9 +11,11 @@ extern "C" void * runai_create_s3_client(const common::s3::StorageUri & uri);
 extern "C" void runai_remove_s3_client(void * client);
 extern "C" common::ResponseCode  runai_async_read_s3_client(void * client, unsigned num_ranges, common::Range * ranges, size_t chunk_bytesize, char * buffer);
 extern "C" common::ResponseCode  runai_async_response_s3_client(void * client, unsigned * index /* output parameter */);
+extern "C" void runai_stop_s3_clients();
 extern "C" void runai_release_s3_clients();
 
 extern "C" void runai_mock_s3_set_response_time_ms(unsigned milliseconds);
 extern "C" int runai_mock_s3_clients();
+extern "C" void runai_mock_s3_cleanup();
 
 }; //namespace runai::llm::streamer::common::s3

--- a/cpp/s3/s3_mock/s3_mock.ldscript
+++ b/cpp/s3/s3_mock/s3_mock.ldscript
@@ -5,7 +5,9 @@
         runai_async_read_s3_client;
         runai_async_response_s3_client;
         runai_mock_s3_clients;
+        runai_stop_s3_clients;
         runai_release_s3_clients;
         runai_mock_s3_set_response_time_ms;
+        runai_mock_s3_cleanup;
     local: *;
 };

--- a/cpp/s3/s3_mock/s3_mock.ldscript
+++ b/cpp/s3/s3_mock/s3_mock.ldscript
@@ -6,5 +6,6 @@
         runai_async_response_s3_client;
         runai_mock_s3_clients;
         runai_release_s3_clients;
+        runai_mock_s3_set_response_time_ms;
     local: *;
 };

--- a/cpp/streamer/impl/batch/BUILD
+++ b/cpp/streamer/impl/batch/BUILD
@@ -18,5 +18,13 @@ runai_cc_test(
             "//streamer/impl/file",
             "//utils/random",
             "//utils/temp/file",
+            "//utils/thread",
+            "//utils/dylib",
+            "//utils/scope_guard",
+            "//s3/s3_mock:libstreamers3.so",
+    ],
+    data = ["//s3/s3_mock:libstreamers3.so"],
+    linkopts = [
+        "-Wl,-rpath,$$ORIGIN/../../../s3/s3_mock",
     ],
 )

--- a/cpp/streamer/impl/batch/BUILD
+++ b/cpp/streamer/impl/batch/BUILD
@@ -21,6 +21,7 @@ runai_cc_test(
             "//utils/thread",
             "//utils/dylib",
             "//utils/scope_guard",
+            "//common/s3_wrapper",
             "//s3/s3_mock:libstreamers3.so",
     ],
     data = ["//s3/s3_mock:libstreamers3.so"],

--- a/cpp/streamer/impl/batch/batch.cc
+++ b/cpp/streamer/impl/batch/batch.cc
@@ -163,7 +163,7 @@ void Batch::read(const Config & config, std::atomic<bool> & stopped)
         finished_until(range.end, common::ResponseCode::Success);
     }
 
-    LOG(DEBUG) << "Finished reading " << i << "/" << num_chunks << " chunks of size " << config.fs_block_bytesize << " from file " << path << (stopped ? " - terminated" : " successfully");
+    LOG(DEBUG) << "Finished reading " << i << "/" << num_chunks << " chunks from file " << path << (stopped ? " - terminated" : " successfully");
 
     if (stopped)
     {

--- a/cpp/streamer/impl/batch/batch.h
+++ b/cpp/streamer/impl/batch/batch.h
@@ -48,7 +48,7 @@ struct Batch
 
     Batch(const std::string & path, std::shared_ptr<common::s3::StorageUri> uri, Range && range, char * dst, const Tasks && tasks, std::shared_ptr<common::Responder> responder, std::shared_ptr<const Config> config);
 
-    void execute();
+    void execute(std::atomic<bool> & stopped);
 
     // notify tasks until file offset
     void finished_until(size_t file_offset, common::ResponseCode ret = common::ResponseCode::Success);
@@ -70,8 +70,8 @@ struct Batch
     std::shared_ptr<const Config> config;
 
  private:
-    void read(const Config & config);
-    void async_read(const Config & config);
+    void read(const Config & config, std::atomic<bool> & stopped);
+    void async_read(const Config & config, std::atomic<bool> & stopped);
 
  private:
     // index of first unfinished task

--- a/cpp/streamer/impl/batch/batch_test.cc
+++ b/cpp/streamer/impl/batch/batch_test.cc
@@ -4,6 +4,7 @@
 #include <utility>
 #include <memory>
 
+#include "utils/logging/logging.h"
 #include "utils/random/random.h"
 #include "utils/temp/file/file.h"
 
@@ -134,7 +135,8 @@ TEST(Read, Sanity)
 
     Batch batch(path, uri, std::move(range), dst_ptr, std::move(tasks), responder, config);
 
-    EXPECT_NO_THROW(batch.execute());
+    std::atomic<bool> stopped;
+    EXPECT_NO_THROW(batch.execute(stopped));
 
     auto r = batch.responder->pop();
     EXPECT_EQ(r.ret, common::ResponseCode::Success);
@@ -197,10 +199,73 @@ TEST(Read, Error)
 
     Batch batch(path, uri, std::move(range), dst_ptr, std::move(tasks), responder, config);
 
-    EXPECT_NO_THROW(batch.execute());
+    std::atomic<bool> stopped;
+    EXPECT_NO_THROW(batch.execute(stopped));
 
     auto r = batch.responder->pop();
     EXPECT_EQ(r.ret, common::ResponseCode::EofError);
+}
+
+TEST(Read, Stopped)
+{
+    // File range to read
+    auto start = utils::random::number<size_t>(0, 1024);
+    auto size = utils::random::number<size_t>(1, 1024 * 1024);
+    auto range = Range(start, start + size);
+    EXPECT_EQ(range.size, size);
+
+    const auto data = utils::random::buffer(start + size);
+    utils::temp::File file(data);
+    const auto path = file.path;
+    std::shared_ptr<common::s3::StorageUri> uri;
+    try
+    {
+        uri = std::make_shared<common::s3::StorageUri>(path);
+    }
+    catch(const std::exception& e)
+    {
+    }
+
+    // divide range into chunks - a chunk per task
+    unsigned num_tasks = utils::random::number(1, 10);
+    auto chunks = utils::random::chunks(range.size, num_tasks);
+
+    auto responder = std::make_shared<common::Responder>(1);
+
+    const auto chunk_bytesize = utils::random::number<size_t>(1, range.size);
+    const auto config = std::make_shared<Config>(utils::random::number(1, 4), chunk_bytesize, utils::random::number<size_t>(1, chunk_bytesize), false /* do not force minimum chunk size */);
+
+    std::vector<char> dst(size);
+    auto dst_ptr = dst.data();
+
+    // create tasks
+    auto request = std::make_shared<Request>(range.start, utils::random::number(), num_tasks, size);
+
+    size_t offset = start;
+
+    Tasks tasks;
+    for (unsigned i = 0; i < num_tasks; ++i)
+    {
+        // task offset is relative to the beginning of the request offset
+        auto task = Task(request, offset, chunks[i]);
+        offset += chunks[i];
+        tasks.push_back(std::move(task));
+    }
+
+    Batch batch(path, uri, std::move(range), dst_ptr, std::move(tasks), responder, config);
+
+    std::atomic<bool> stopped(true);
+    EXPECT_NO_THROW(batch.execute(stopped));
+
+    auto r = batch.responder->pop();
+    EXPECT_EQ(r.ret, common::ResponseCode::FinishedError);
+
+    // verify data not read
+    size_t i = 0;
+    for (size_t i = 0; i < size && dst[i] == data[i]; ++i)
+    {
+    }
+    EXPECT_LT(i, size);
 }
 
 }; // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/batch/batch_test.cc
+++ b/cpp/streamer/impl/batch/batch_test.cc
@@ -3,10 +3,15 @@
 #include <gtest/gtest.h>
 #include <utility>
 #include <memory>
+#include <chrono>
+#include <set>
 
 #include "utils/logging/logging.h"
 #include "utils/random/random.h"
 #include "utils/temp/file/file.h"
+#include "utils/thread/thread.h"
+#include "utils/dylib/dylib.h"
+#include "utils/scope_guard/scope_guard.h"
 
 #include "streamer/impl/file/file.h"
 
@@ -15,12 +20,14 @@ namespace runai::llm::streamer::impl
 
 TEST(Batch, Finished_Until)
 {
+    unsigned num_tasks = utils::random::number(1, 10);
+
     // File range to read
     auto start = utils::random::number<size_t>(0, 1024);
-    auto size = utils::random::number<size_t>(1, 1024 * 1024);
+    auto size = utils::random::number<size_t>(num_tasks, 1024 * 1024);
+    EXPECT_LT(num_tasks, size);
 
     // divide range into chunks - a chunk per task
-    unsigned num_tasks = utils::random::number(1, 10);
     auto chunks = utils::random::chunks(size, num_tasks);
 
     auto responder = std::make_shared<common::Responder>(1);
@@ -79,7 +86,7 @@ TEST(Batch, Finished_Until)
 
     // execute rest of the tasks
 
-    batch.finished_until(batch.range.end);
+    batch.finished_until(expected_range.end);
 
     EXPECT_EQ(batch.finished_until(), num_tasks);
 
@@ -89,9 +96,13 @@ TEST(Batch, Finished_Until)
 
 TEST(Read, Sanity)
 {
+    unsigned num_tasks = utils::random::number(1, 10);
+
     // File range to read
-    auto start = utils::random::number<size_t>(0, 1024);
-    auto size = utils::random::number<size_t>(1, 1024 * 1024);
+    const auto start = utils::random::number<size_t>(0, 1024);
+    const auto size = utils::random::number<size_t>(num_tasks, 1024 * 1024);
+    EXPECT_LT(num_tasks, size);
+
     auto range = Range(start, start + size);
     EXPECT_EQ(range.size, size);
 
@@ -108,7 +119,6 @@ TEST(Read, Sanity)
     }
 
     // divide range into chunks - a chunk per task
-    unsigned num_tasks = utils::random::number(1, 10);
     auto chunks = utils::random::chunks(range.size, num_tasks);
 
     auto responder = std::make_shared<common::Responder>(1);
@@ -135,26 +145,31 @@ TEST(Read, Sanity)
 
     Batch batch(path, uri, std::move(range), dst_ptr, std::move(tasks), responder, config);
 
-    std::atomic<bool> stopped;
+    std::atomic<bool> stopped(false);
     EXPECT_NO_THROW(batch.execute(stopped));
 
     auto r = batch.responder->pop();
     EXPECT_EQ(r.ret, common::ResponseCode::Success);
 
     // verify read data
-    for (size_t i = 0; i < size && dst[i] == data[i]; ++i)
+    bool mismatch = false;
+    for (size_t i = 0; i < size && !mismatch; ++i)
     {
-        EXPECT_EQ(dst[i], data[i]);
+        mismatch = dst[i] != static_cast<char>(data[start + i]);
     }
+    EXPECT_FALSE(mismatch);
 }
 
 TEST(Read, Error)
 {
     std::string path;
+    unsigned num_tasks = utils::random::number(2, 10); // need at least two tasks in this test
 
     // File range to read
     auto start = utils::random::number<size_t>(0, 1024);
-    auto size = utils::random::number<size_t>(2, 1024 * 1024);
+    auto size = utils::random::number<size_t>(num_tasks, 1024 * 1024);
+    EXPECT_LT(num_tasks, size);
+
     auto range = Range(start, start + size);
     EXPECT_EQ(range.size, size);
 
@@ -163,7 +178,6 @@ TEST(Read, Error)
     path = file.path;
 
     // divide range into chunks - a chunk per task
-    unsigned num_tasks = utils::random::number(1, 10);
     auto chunks = utils::random::chunks(range.size, num_tasks);
 
     auto responder = std::make_shared<common::Responder>(1);
@@ -199,18 +213,22 @@ TEST(Read, Error)
 
     Batch batch(path, uri, std::move(range), dst_ptr, std::move(tasks), responder, config);
 
-    std::atomic<bool> stopped;
+    std::atomic<bool> stopped(false);
     EXPECT_NO_THROW(batch.execute(stopped));
 
     auto r = batch.responder->pop();
     EXPECT_EQ(r.ret, common::ResponseCode::EofError);
 }
 
-TEST(Read, Stopped)
+TEST(Read, Already_Stopped)
 {
+    unsigned num_tasks = utils::random::number(1, 10);
+
     // File range to read
     auto start = utils::random::number<size_t>(0, 1024);
-    auto size = utils::random::number<size_t>(1, 1024 * 1024);
+    auto size = utils::random::number<size_t>(num_tasks, 1024 * 1024);
+    EXPECT_LT(num_tasks, size);
+
     auto range = Range(start, start + size);
     EXPECT_EQ(range.size, size);
 
@@ -227,7 +245,6 @@ TEST(Read, Stopped)
     }
 
     // divide range into chunks - a chunk per task
-    unsigned num_tasks = utils::random::number(1, 10);
     auto chunks = utils::random::chunks(range.size, num_tasks);
 
     auto responder = std::make_shared<common::Responder>(1);
@@ -261,11 +278,240 @@ TEST(Read, Stopped)
     EXPECT_EQ(r.ret, common::ResponseCode::FinishedError);
 
     // verify data not read
-    size_t i = 0;
-    for (size_t i = 0; i < size && dst[i] == data[i]; ++i)
+    bool mismatch = false;
+    for (size_t i = 0; i < size && !mismatch; ++i)
+    {
+        mismatch = dst[i] != static_cast<char>(data[start + i]);
+    }
+    EXPECT_TRUE(mismatch);
+}
+
+TEST(Read, Stopped_During_Read)
+{
+    unsigned num_requests = utils::random::number(1, 10);
+
+    // File range to read
+    const auto start = utils::random::number<size_t>(0, 1024);
+    const auto size = utils::random::number<size_t>(512 * 1024, 1024 * 1024);
+    EXPECT_LT(num_requests, size);
+
+    auto range = Range(start, start + size);
+    EXPECT_EQ(range.size, size);
+
+    const auto data = utils::random::buffer(start + size);
+    utils::temp::File file(data);
+    const auto path = file.path;
+    std::shared_ptr<common::s3::StorageUri> uri;
+    try
+    {
+        uri = std::make_shared<common::s3::StorageUri>(path);
+    }
+    catch(const std::exception& e)
     {
     }
-    EXPECT_LT(i, size);
+
+    // divide range into chunks - a chunk per request
+
+    const auto chunks = utils::random::chunks(range.size, num_requests);
+
+    auto responder = std::make_shared<common::Responder>(num_requests);
+
+    const auto chunk_bytesize = utils::random::number<size_t>(1, range.size);
+    const auto config = std::make_shared<Config>(utils::random::number(1, 4), chunk_bytesize, utils::random::number<size_t>(1, chunk_bytesize), false /* do not force minimum chunk size */);
+
+    std::vector<char> dst(size);
+    auto dst_ptr = dst.data();
+
+    // create task for each request
+    Tasks tasks;
+    std::vector<std::shared_ptr<Request>> requests(num_requests);
+    std::vector<size_t> offsets;
+    auto offset = start;
+    for (unsigned i = 0; i < num_requests; ++i)
+    {
+        requests[i] = std::make_shared<Request>(offset, i, 1, chunks[i]);
+        EXPECT_EQ(requests[i]->bytesize, chunks[i]);
+        EXPECT_EQ(requests[i]->offset, offset);
+
+        // task offset is relative to the beginning of the request offset
+        auto task = Task(requests[i], offset, chunks[i]);
+        tasks.push_back(std::move(task));
+
+        offsets.push_back(offset);
+        offset += chunks[i];
+    }
+
+    Batch batch(path, uri, std::move(range), dst_ptr, std::move(tasks), responder, config);
+
+    std::atomic<bool> stopped(false);
+
+    auto thread = utils::Thread([&]()
+    {
+        EXPECT_NO_THROW(batch.execute(stopped));
+    });
+
+    ::usleep(utils::random::number(300));
+    stopped = true;
+
+    // collect responses
+    std::vector<common::Response> responses;
+    std::set<unsigned> responded_requests;
+    for (unsigned i = 0; i < num_requests; ++i)
+    {
+        auto r = batch.responder->pop();
+        responded_requests.insert(r.index);
+        responses.push_back(r);
+    }
+
+    EXPECT_EQ(responded_requests.size(), num_requests);
+
+    auto r = batch.responder->pop();
+    EXPECT_EQ(r.ret, common::ResponseCode::FinishedError);
+
+    // verify that all responses were sent
+    for (const auto & r : responses)
+    {
+        EXPECT_LT(r.index, num_requests);
+
+        bool mismatch = false;
+        const auto j_start = offsets[r.index]; // request offset is the file offset
+        const auto j_end = j_start + chunks[r.index];
+        for (size_t j = j_start; j < j_end; ++j)
+        {
+            char dst_ = dst[j - start];
+            char data_ =  static_cast<char>(data[j]);
+            mismatch = (data_ != dst_);
+            if (mismatch)
+            {
+                break;
+            }
+        }
+
+        if (r.ret == common::ResponseCode::Success)
+        {
+            // verify read data
+            EXPECT_FALSE(mismatch);
+        }
+        else
+        {
+            EXPECT_EQ(r.ret, common::ResponseCode::FinishedError);
+            // verify unread data
+            EXPECT_TRUE(mismatch);
+        }
+    }
+}
+
+TEST(Read, Stopped_During_Async_Read)
+{
+    // mock S3
+    utils::Dylib dylib("libstreamers3.so");
+    auto mock_response_time = dylib.dlsym<void(*)(unsigned)>("runai_mock_s3_set_response_time_ms");
+    unsigned delay_ms = 1000;
+    mock_response_time(delay_ms);
+    auto guard = utils::ScopeGuard([&mock_response_time](){
+        mock_response_time(0);
+    });
+
+    unsigned num_requests = utils::random::number(1, 10);
+
+    // File range to read
+    const auto start = utils::random::number<size_t>(0, 1024);
+    const auto size = utils::random::number<size_t>(512 * 1024, 1024 * 1024);
+    EXPECT_LT(num_requests, size);
+
+    auto range = Range(start, start + size);
+    EXPECT_EQ(range.size, size);
+
+    const auto data = utils::random::buffer(start + size);
+    std::string path("s3://" + utils::random::string() + "/" + utils::random::string());
+
+    std::shared_ptr<common::s3::StorageUri> uri;
+    EXPECT_NO_THROW(uri = std::make_shared<common::s3::StorageUri>(path));
+
+    // divide range into chunks - a chunk per request
+
+    const auto chunks = utils::random::chunks(range.size, num_requests);
+
+    auto responder = std::make_shared<common::Responder>(num_requests);
+
+    const auto chunk_bytesize = utils::random::number<size_t>(1, range.size);
+    const auto config = std::make_shared<Config>(utils::random::number(1, 4), chunk_bytesize, utils::random::number<size_t>(1, chunk_bytesize), false /* do not force minimum chunk size */);
+
+    std::vector<char> dst(size);
+    auto dst_ptr = dst.data();
+
+    // create task for each request
+    Tasks tasks;
+    std::vector<std::shared_ptr<Request>> requests(num_requests);
+    std::vector<size_t> offsets;
+    auto offset = start;
+    for (unsigned i = 0; i < num_requests; ++i)
+    {
+        requests[i] = std::make_shared<Request>(offset, i, 1, chunks[i]);
+        EXPECT_EQ(requests[i]->bytesize, chunks[i]);
+        EXPECT_EQ(requests[i]->offset, offset);
+
+        // task offset is relative to the beginning of the request offset
+        auto task = Task(requests[i], offset, chunks[i]);
+        tasks.push_back(std::move(task));
+
+        offsets.push_back(offset);
+        offset += chunks[i];
+    }
+
+    Batch batch(path, uri, std::move(range), dst_ptr, std::move(tasks), responder, config);
+
+    std::atomic<bool> stopped(false);
+
+    auto thread = utils::Thread([&]()
+    {
+        EXPECT_NO_THROW(batch.execute(stopped));
+    });
+
+    ::usleep(utils::random::number(300));
+    stopped = true;
+
+    // collect responses
+    const auto start_time = std::chrono::steady_clock::now();
+    std::vector<common::Response> responses;
+    std::set<unsigned> responded_requests;
+    for (unsigned i = 0; i < num_requests; ++i)
+    {
+        auto r = batch.responder->pop();
+        responded_requests.insert(r.index);
+        responses.push_back(r);
+    }
+
+    const auto end_time = std::chrono::steady_clock::now();
+    const auto duration  = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
+
+    if (num_requests > 1)
+    {
+        // verify that not all the requests were executed
+        EXPECT_LT(duration.count(), num_requests * delay_ms);
+    }
+
+    EXPECT_EQ(responded_requests.size(), num_requests);
+
+    auto r = batch.responder->pop();
+    EXPECT_EQ(r.ret, common::ResponseCode::FinishedError);
+
+    unsigned count_terminated = 0;
+    for (const auto & r : responses)
+    {
+        EXPECT_LT(r.index, num_requests);
+
+        if (r.ret != common::ResponseCode::Success)
+        {
+            EXPECT_EQ(r.ret, common::ResponseCode::FinishedError);
+            ++count_terminated;
+        }
+    }
+
+    if (num_requests > 1)
+    {
+        EXPECT_GT(count_terminated, 0);
+    }
 }
 
 }; // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/batches/batches_test.cc
+++ b/cpp/streamer/impl/batches/batches_test.cc
@@ -15,11 +15,13 @@ namespace runai::llm::streamer::impl
 TEST(Batches, Sanity)
 {
     auto size = utils::random::number(1000, 100000);
+    const unsigned num_chunks = utils::random::number(1, 20);
+    EXPECT_LT(num_chunks, size);
+
     const auto data = utils::random::buffer(size);
     utils::temp::File file(data);
 
     // create internal division to divide the file into requests (each request represent a tensor)
-    const unsigned num_chunks = utils::random::number(1, 20);
     auto chunks = utils::random::chunks(size, num_chunks);
 
     const auto chunk_size = utils::random::number<size_t>(1, 1024);
@@ -86,6 +88,8 @@ TEST(Batches, Failed_Reader)
 
     // create internal division
     const unsigned num_chunks = utils::random::number(2, 20);
+    EXPECT_LT(num_chunks, size);
+
     auto chunks = utils::random::chunks(size, num_chunks);
 
     const auto chunk_size = utils::random::number<size_t>(1, 1024);

--- a/cpp/streamer/impl/request/request_test.cc
+++ b/cpp/streamer/impl/request/request_test.cc
@@ -17,7 +17,7 @@ TEST(Creation, Sanity)
     std::atomic<unsigned int> finished = 0;
     unsigned retries = 5;
 
-    auto pool = utils::ThreadPool<int>([&](int i)
+    auto pool = utils::ThreadPool<int>([&](int i, std::atomic<bool> &)
     {
         finished += request.finished();
     }, utils::random::number(1, 2 * num_tasks));

--- a/cpp/streamer/impl/s3/s3.cc
+++ b/cpp/streamer/impl/s3/s3.cc
@@ -54,4 +54,15 @@ S3Cleanup::~S3Cleanup()
     }
 }
 
+S3Stop::~S3Stop()
+{
+    try
+    {
+        common::s3::S3ClientWrapper::stop();
+    }
+    catch(...)
+    {
+    }
+}
+
 }; // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/s3/s3.h
+++ b/cpp/streamer/impl/s3/s3.h
@@ -17,6 +17,13 @@ struct S3Cleanup
     ~S3Cleanup();
 };
 
+struct S3Stop
+{
+    S3Stop() = default;
+
+    ~S3Stop();
+};
+
 struct S3 : Reader
 {
     S3(std::shared_ptr<common::s3::S3ClientWrapper> client, const Config & config);

--- a/cpp/streamer/impl/streamer/streamer.cc
+++ b/cpp/streamer/impl/streamer/streamer.cc
@@ -1,5 +1,6 @@
 #include "streamer/impl/streamer/streamer.h"
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <utility>
@@ -19,9 +20,9 @@ Streamer::Streamer() : Streamer(Config())
 
 Streamer::Streamer(Config config) :
     _config(std::make_shared<Config>(config)),
-    _pool([&](Batch batch)
+    _pool([&](Batch batch, std::atomic<bool> & stopped)
         {
-            batch.execute();
+            batch.execute(stopped);
         }, _config->concurrency)
 {
     LOG(DEBUG) << config;

--- a/cpp/streamer/impl/streamer/streamer.cc
+++ b/cpp/streamer/impl/streamer/streamer.cc
@@ -30,7 +30,12 @@ Streamer::Streamer(Config config) :
 
 Streamer::~Streamer()
 {
-    LOG(DEBUG) << "Streamer shutting down";
+    try
+    {
+        LOG(DEBUG) << "Streamer shutting down";
+    }
+    catch(...)
+    {}
 }
 
 common::ResponseCode Streamer::request(const std::string & path, size_t file_offset, size_t bytesize, void * dst)
@@ -104,6 +109,7 @@ void Streamer::create_request(const std::string & path, size_t file_offset, size
         uri = std::make_unique<common::s3::StorageUri>(path);
         if (_s3 == nullptr)
         {
+            _s3_stop = std::make_unique<S3Stop>();
             _s3 = std::make_unique<S3Cleanup>();
         }
     }

--- a/cpp/streamer/impl/streamer/streamer.h
+++ b/cpp/streamer/impl/streamer/streamer.h
@@ -54,6 +54,7 @@ struct Streamer
     std::shared_ptr<const Config> _config;
     std::unique_ptr<S3Cleanup> _s3;
     utils::ThreadPool<Batch> _pool;
+    std::unique_ptr<S3Stop> _s3_stop;
     std::shared_ptr<common::Responder> _responder;
 };
 

--- a/cpp/streamer/impl/streamer/streamer_test.cc
+++ b/cpp/streamer/impl/streamer/streamer_test.cc
@@ -258,25 +258,28 @@ TEST(Async, End_Of_File_Error)
     // write data just for the first chunks
 
     const auto chunk_size = utils::random::number<size_t>(10, size - 1);
-    const auto bulk_size = utils::random::number<size_t>(1, chunk_size);
+    const auto block_size = utils::random::number<size_t>(1, chunk_size);
 
+    LOG(DEBUG) << "writing only " << chunk_size << " bytes";
     const auto data = utils::random::buffer(chunk_size);
     utils::temp::File file(data);
 
-    size_t num_bulks = chunk_size/bulk_size;
-    size_t successful_bytesize = num_bulks * bulk_size;
+    size_t num_blocks = chunk_size/block_size;
+    size_t successful_bytesize = num_blocks * block_size;
     size_t total = 0;
     unsigned expected = 0;
 
     while (total < successful_bytesize && expected < num_chunks)
     {
         total += chunks[expected];
+        if (total > successful_bytesize)
+        {
+            break;
+        }
         ++expected;
     }
 
-    expected = (total <= successful_bytesize ? expected : expected - 1);
-
-    Config config(utils::random::number(1, 20), chunk_size, bulk_size, false /* do not enforce minimum */);
+    Config config(utils::random::number(1, 20), chunk_size, block_size, false /* do not enforce minimum */);
     Streamer streamer(config);
 
     std::vector<char> dst(size);

--- a/cpp/streamer/impl/streamer/streamer_test.cc
+++ b/cpp/streamer/impl/streamer/streamer_test.cc
@@ -178,6 +178,7 @@ TEST(Async, Requests)
 
     // create internal division
     const unsigned num_chunks = utils::random::number(1, 20);
+    EXPECT_LT(num_chunks, size);
     auto chunks = utils::random::chunks(size, num_chunks);
 
     const auto chunk_size = utils::random::number<size_t>(1, 1024);
@@ -225,6 +226,7 @@ TEST(Async, File_Not_Found_Error)
 
     // create internal division
     const unsigned num_chunks = utils::random::number(1, 20);
+    EXPECT_LT(num_chunks, size);
     auto chunks = utils::random::chunks(size, num_chunks);
 
     const auto chunk_size = utils::random::number<size_t>(1, 1024);
@@ -249,6 +251,8 @@ TEST(Async, End_Of_File_Error)
 
     // create internal division
     const unsigned num_chunks = utils::random::number(1, 20);
+    EXPECT_LT(num_chunks, size);
+
     auto chunks = utils::random::chunks(size, num_chunks);
 
     // write data just for the first chunks
@@ -309,6 +313,8 @@ TEST(Async, Zero_Requests_Error)
 
     // create internal division
     const unsigned num_chunks = utils::random::number(1, 20);
+    EXPECT_LT(num_chunks, size);
+
     auto chunks = utils::random::chunks(size, num_chunks);
 
     const auto chunk_size = utils::random::number<size_t>(1, 1024);
@@ -333,6 +339,8 @@ TEST(Async, Zero_Bytes_To_Read_Error)
 
     // create internal division
     const unsigned num_chunks = utils::random::number(1, 20);
+    EXPECT_LT(num_chunks, size);
+
     auto chunks = utils::random::chunks(size, num_chunks);
 
     const auto chunk_size = utils::random::number<size_t>(1, 1024);

--- a/cpp/streamer/impl/task/task.cc
+++ b/cpp/streamer/impl/task/task.cc
@@ -21,6 +21,20 @@ Task::Task(std::shared_ptr<Request> request, Info && info) :
     info(info)
 {}
 
+// returns true if the request is completed (i.e. all its tasks were finished)
+bool Task::finished_request(common::ResponseCode ret)
+{
+    if (_finished)
+    {
+        // do nothing
+        return false;
+    }
+
+    _finished = true;
+    return request->finished(ret);
+}
+
+
 std::ostream & operator<<(std::ostream & os, const Task & task)
 {
     os << "task to read " << task.info.bytesize << " bytes from file offset " << task.info.offset << " to " << task.info.end;

--- a/cpp/streamer/impl/task/task.h
+++ b/cpp/streamer/impl/task/task.h
@@ -25,9 +25,12 @@ struct Task
     Task(std::shared_ptr<Request> request, Info && info);
     Task(std::shared_ptr<Request> request, size_t offset, size_t bytesize);
 
+    bool finished_request(common::ResponseCode ret);
+
     std::shared_ptr<Request> request;
     Info info;
-    bool finished = false;
+ private:
+    bool _finished = false;
 };
 
 std::ostream & operator<<(std::ostream &, const Task &);

--- a/cpp/streamer/impl/task/task.h
+++ b/cpp/streamer/impl/task/task.h
@@ -27,6 +27,7 @@ struct Task
 
     std::shared_ptr<Request> request;
     Info info;
+    bool finished = false;
 };
 
 std::ostream & operator<<(std::ostream &, const Task &);

--- a/cpp/streamer/streamer_s3_test.cc
+++ b/cpp/streamer/streamer_s3_test.cc
@@ -62,12 +62,13 @@ TEST_F(StreamerTest, Async_Read)
     auto verify_mock = dylib.dlsym<int(*)(void)>("runai_mock_s3_clients");
 
     auto total_size = utils::random::number(100, 10000);
+    const auto num_chunks = utils::random::number(1, 10);
+    EXPECT_LT(num_chunks, total_size);
 
     void * streamer;
     auto res = runai_start(&streamer);
     EXPECT_EQ(res, static_cast<int>(common::ResponseCode::Success));
 
-    const auto num_chunks = utils::random::number(1, 10);
     const auto chunks = utils::random::chunks(total_size, num_chunks);
 
     std::vector<char> dst(total_size);

--- a/cpp/streamer/streamer_s3_test.cc
+++ b/cpp/streamer/streamer_s3_test.cc
@@ -26,6 +26,13 @@ struct StreamerTest : ::testing::Test
         s3_path("s3://" + utils::random::string() + "/" + utils::random::string())
     {}
 
+    ~StreamerTest()
+    {
+        utils::Dylib dylib("libstreamers3.so");
+        auto mock_cleanup = dylib.dlsym<void(*)()>("runai_mock_s3_cleanup");
+        mock_cleanup();
+    }
+
  protected:
     utils::temp::Env _size;
     utils::temp::Env _chunk_bytesize;
@@ -105,6 +112,7 @@ TEST_F(StreamerTest, Error)
 {
     utils::Dylib dylib("libstreamers3.so");
     auto verify_mock = dylib.dlsym<int(*)(void)>("runai_mock_s3_clients");
+    auto mock_cleanup = dylib.dlsym<void(*)()>("runai_mock_s3_cleanup");
 
     for (const auto response_code : { common::ResponseCode::FileAccessError, common::ResponseCode::InvalidParameterError })
     {
@@ -123,7 +131,83 @@ TEST_F(StreamerTest, Error)
 
         runai_end(streamer);
         EXPECT_EQ(verify_mock(), 0);
+        mock_cleanup();
     }
+}
+
+TEST_F(StreamerTest, Stop_Before_Async_Read)
+{
+    utils::Dylib dylib("libstreamers3.so");
+    auto verify_mock = dylib.dlsym<int(*)(void)>("runai_mock_s3_clients");
+    auto stop_mock = dylib.dlsym<void(*)(void)>("runai_stop_s3_clients");
+
+    auto total_size = utils::random::number(100, 10000);
+    const auto num_chunks = utils::random::number(1, 10);
+    EXPECT_LT(num_chunks, total_size);
+
+    void * streamer;
+    auto res = runai_start(&streamer);
+    EXPECT_EQ(res, static_cast<int>(common::ResponseCode::Success));
+
+    const auto chunks = utils::random::chunks(total_size, num_chunks);
+
+    std::vector<char> dst(total_size);
+    std::vector<size_t> sizes;
+
+    const auto offset = utils::random::number<size_t>();
+
+    for (unsigned i = 0; i < num_chunks; ++i)
+    {
+        sizes.push_back(chunks[i]);
+    }
+
+    stop_mock();
+    EXPECT_EQ(runai_request(streamer, s3_path.c_str(), offset, total_size, dst.data(), sizes.size(), sizes.data()), static_cast<int>(common::ResponseCode::Success));
+
+    // request was not sent to the S3 server
+    unsigned r;
+    EXPECT_EQ(runai_response(streamer, &r), static_cast<int>(common::ResponseCode::FinishedError));
+
+    runai_end(streamer);
+    EXPECT_EQ(verify_mock(), 0);
+}
+
+TEST_F(StreamerTest, End_During_Async_Read)
+{
+    utils::Dylib dylib("libstreamers3.so");
+    auto verify_mock = dylib.dlsym<int(*)(void)>("runai_mock_s3_clients");
+
+    auto mock_response_time = dylib.dlsym<void(*)(unsigned)>("runai_mock_s3_set_response_time_ms");
+    unsigned delay_ms = 1000;
+    mock_response_time(delay_ms);
+
+    auto total_size = utils::random::number(100, 10000);
+    const auto num_chunks = utils::random::number(1, 10);
+    EXPECT_LT(num_chunks, total_size);
+
+    void * streamer;
+    auto res = runai_start(&streamer);
+    EXPECT_EQ(res, static_cast<int>(common::ResponseCode::Success));
+
+    const auto chunks = utils::random::chunks(total_size, num_chunks);
+
+    std::vector<char> dst(total_size);
+    std::vector<size_t> sizes;
+
+    const auto offset = utils::random::number<size_t>();
+
+    for (unsigned i = 0; i < num_chunks; ++i)
+    {
+        sizes.push_back(chunks[i]);
+    }
+
+    EXPECT_EQ(runai_request(streamer, s3_path.c_str(), offset, total_size, dst.data(), sizes.size(), sizes.data()), static_cast<int>(common::ResponseCode::Success));
+
+    ::usleep(utils::random::number(300));
+
+    runai_end(streamer);
+
+    EXPECT_EQ(verify_mock(), 0);
 }
 
 }; // namespace runai::llm::streamer

--- a/cpp/streamer/streamer_test.cc
+++ b/cpp/streamer/streamer_test.cc
@@ -220,12 +220,9 @@ TEST_F(StreamerTest, S3_Library_Not_Found)
 
 TEST_F(StreamerTest, End_Before_Read)
 {
-    auto size = utils::random::number(100000000, 1000000000);
+    auto size = utils::random::number(10000000, 100000000);
     const auto data = utils::random::buffer(size);
     utils::temp::File file(data);
-
-    const auto expected = utils::Fd::read(file.path);
-    EXPECT_EQ(expected.size(), size);
 
     void * streamer;
     auto res = runai_start(&streamer);
@@ -237,7 +234,7 @@ TEST_F(StreamerTest, End_Before_Read)
 
     EXPECT_EQ(runai_request(streamer, file.path.c_str(), 0, size, dst.data(), 1, sizes.data()), static_cast<int>(common::ResponseCode::Success));
 
-    ::usleep(utils::random::number(20000));
+    ::usleep(utils::random::number(400));
 
     const auto start_time = std::chrono::steady_clock::now();
     runai_end(streamer);

--- a/cpp/utils/thread/thread.h
+++ b/cpp/utils/thread/thread.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <thread>
 #include <string>
+#include <atomic>
 
 namespace runai::llm::streamer::utils
 {

--- a/cpp/utils/thread/thread.h
+++ b/cpp/utils/thread/thread.h
@@ -3,7 +3,6 @@
 #include <functional>
 #include <thread>
 #include <string>
-#include <atomic>
 
 namespace runai::llm::streamer::utils
 {

--- a/cpp/utils/threadpool/threadpool.h
+++ b/cpp/utils/threadpool/threadpool.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <utility>
 #include <vector>
 #include <string>


### PR DESCRIPTION
Created shutdown path when runai_end is called, which stops the reading and returns response code `FinishedError`

However, read requests which were already sent to the storage cannot be cancelled. 

When reading from file system, each thread sends synchronous read request one by one, so the maximal waiting time to exit is the time to read a single chunk.

However, when reading from S3, each thread sends all the multi part asynchronous read requests to its `S3CrtClient` for the entire range.
The `S3CrtClient` does not support cancelling asynchronous read requests. Once the requests were sent to the client, the `S3CrtClient` destructor is blocked until they are all responded.

A stop mechanism was added to the `Responder` class, to release any blocking threads which are waiting for response.

The general shutdown flow is as follows:
1. stop all the S3 wrapper client objects, which stops sending requests and also stops the `Responder` object of each client
2. Any thread that is blocked on a response from its S3 wrapper client will be released, because the responder was stopped
3. The main streamer's thread pool is destructed, since all the threads are joined
4. Destroy all the S3 clients 

