### PR TITLE
Fix FileStreamer output encoded

### DIFF
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -17,7 +17,7 @@ jobs:
       uses: devcontainers/ci@v0.3
       with:
         runCmd: |
-          make test
+          make test && \
           PACKAGE_VERSION=${{ env.PACKAGE_VERSION }} make build
 
     - name: Set package file names

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 .PHONY: build test install
 
 build:
-	make -C cpp clean
-	make -C py clean
-	make -C cpp build
+	make -C cpp clean && \
+	make -C py clean && \
+	make -C cpp build && \
 	make -C py build
 
 install: build
 	make -C py install
 
 test: install
-	make -C cpp test
-	make -C py test
+	make -C cpp test && \
+	make -C py test && \
 	make -C tests all
 

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build build_mock test
 
 build:
-	bazel build streamer:libstreamer.so
+	bazel build streamer:libstreamer.so && \
 	bazel build --define USE_SYSTEM_LIBS=${USE_SYSTEM_LIBS} s3:libstreamers3.so
 
 build_mock:

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_file_streamer.py
@@ -30,7 +30,7 @@ class TestBindings(unittest.TestCase):
             for id, dst, offset in fs.get_chunks():
                 self.assertEqual(offset, id_to_results[id]["expected_offset"])
                 self.assertEqual(
-                    dst[offset : offset + request_sizes[id]].decode("utf-8"),
+                    dst[offset : offset + request_sizes[id]].tobytes().decode("utf-8"),
                     id_to_results[id]["expected_text"],
                 )
 
@@ -63,7 +63,7 @@ class TestBindings(unittest.TestCase):
             for id, dst, offset in fs.get_chunks():
                 self.assertEqual(offset, id_to_results[id]["expected_offset"])
                 self.assertEqual(
-                    dst[offset : offset + request_sizes[id]].decode("utf-8"),
+                    dst[offset : offset + request_sizes[id]].tobytes().decode("utf-8"),
                     id_to_results[id]["expected_text"],
                 )
 
@@ -95,7 +95,7 @@ class TestBindings(unittest.TestCase):
             for id, dst, offset in fs.get_chunks():
                 self.assertEqual(offset, id_to_results[id]["expected_offset"])
                 self.assertEqual(
-                    dst[offset : offset + request_sizes[id]].decode("utf-8"),
+                    dst[offset : offset + request_sizes[id]].tobytes(),
                     id_to_results[id]["expected_text"],
                 )
 

--- a/tests/fuzzing/test_file_streamer.py
+++ b/tests/fuzzing/test_file_streamer.py
@@ -69,7 +69,7 @@ class TestFuzzing(unittest.TestCase):
             for id, dst, offset in fs.get_chunks():
                 self.assertEqual(offset, expected_id_to_results[id]["expected_offset"])
                 self.assertEqual(
-                    dst[offset : offset + request_sizes[id]],
+                    dst[offset : offset + request_sizes[id]].tobytes(),
                     expected_id_to_results[id]["expected_content"],
                 )
 


### PR DESCRIPTION
In this commit:https://github.com/run-ai/runai-model-streamer/commit/ddd0667988a03d96822aa7a51014a6e60443a866
We have changed the buffer type we use in `FileStreamer`, we use `ndarray` instead of `mmap`.
This leads to output of different type of array, which the tests was not expecting