### PR TITLE
Compile streamer to arm arch

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,6 +10,12 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 RUN pip install \
     cpplint==1.5.4
 
+RUN mkdir -p /opt/toolchains && \
+    wget "https://releases.linaro.org/components/toolchain/binaries/7.2-2017.11/aarch64-linux-gnu/gcc-linaro-7.2.1-2017.11-x86_64_aarch64-linux-gnu.tar.xz" && \
+    tar -xf gcc-linaro-7.2.1-2017.11-x86_64_aarch64-linux-gnu.tar.xz -C /opt/toolchains && \
+    mv /opt/toolchains/gcc-linaro-7.2.1-2017.11-x86_64_aarch64-linux-gnu /opt/toolchains/aarch64-linux-gnu && \
+    rm -f gcc-linaro-7.2.1-2017.11-x86_64_aarch64-linux-gnu.tar.xz
+
 ARG BAZEL=4.2.1
 RUN ARCH=$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || uname -m); \
     wget -O /usr/local/bin/bazel "https://github.com/bazelbuild/bazel/releases/download/$BAZEL/bazel-$BAZEL-linux-$ARCH" && \

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,19 @@
-.PHONY: build test install
+.PHONY: build build_aarch64 build_native test install
 
-build:
+build_native:
 	make -C cpp clean && \
-	make -C py clean && \
 	make -C cpp build && \
 	make -C py build
+
+build_aarch64:
+	make -C cpp clean && \
+	make -C cpp build ARCH=aarch64 && \
+	make -C py build ARCH=aarch64
+
+build: 
+	make -C py clean && \
+	make build_native && \
+	make build_aarch64
 
 install: build
 	make -C py install

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -1,8 +1,8 @@
 .PHONY: build build_mock test
 
 build:
-	bazel build streamer:libstreamer.so && \
-	bazel build --define USE_SYSTEM_LIBS=${USE_SYSTEM_LIBS} s3:libstreamers3.so
+	bazel build streamer:libstreamer.so $$( [ -n "${ARCH}" ] && echo "--crosstool_top=@${ARCH}//:toolchain" ) && \
+	bazel build --define USE_SYSTEM_LIBS=${USE_SYSTEM_LIBS} s3:libstreamers3.so $$( [ -n "${ARCH}" ] && echo "--crosstool_top=@${ARCH}//:toolchain" )
 
 build_mock:
 	bazel build mock:libstreamer-mock.so

--- a/cpp/WORKSPACE
+++ b/cpp/WORKSPACE
@@ -1,6 +1,7 @@
-local_repository(name = "cc", path = "../external/cc")
+load("//toolchain:rules.bzl", "runai_cc_configure_toolchain", "runai_cc_autoconf_impl_x86", "runai_cc_autoconf_impl_arm64")
 
-local_repository(name = "elements", path = "../external/elements")
+runai_cc_configure_toolchain("x86_64", runai_cc_autoconf_impl_x86)
+runai_cc_configure_toolchain("aarch64", runai_cc_autoconf_impl_arm64)
 
 new_local_repository(
     name = "aws",

--- a/cpp/toolchain/rules.bzl
+++ b/cpp/toolchain/rules.bzl
@@ -1,0 +1,108 @@
+load(
+    "@bazel_tools//tools/cpp:cc_configure.bzl",
+    "cc_autoconf_impl",
+    "cc_autoconf_toolchains",
+)
+
+def __tool_path(toolchain_name, tool_name):
+    if toolchain_name:
+        return "/opt/toolchains/" + toolchain_name + "/bin/" + toolchain_name + "-" + tool_name
+    else:
+        return "/usr/bin/" + tool_name
+
+def runai_crosstool_tools(toolchain_name):
+    return {
+        "ld.gold":      __tool_path(toolchain_name, "ld.gold"),
+        "gcc":     __tool_path(toolchain_name, "gcc"),
+        "g++":     __tool_path(toolchain_name, "g++"),
+        "ld":      __tool_path(toolchain_name, "ld"),
+        "ar":      __tool_path(toolchain_name, "ar"),
+        "cpp":     __tool_path(toolchain_name, "cpp"),
+        "gcov":    __tool_path(toolchain_name, "gcov"),
+        "nm":      __tool_path(toolchain_name, "nm"),
+        "objdump": __tool_path(toolchain_name, "objdump"),
+        "strip":   __tool_path(toolchain_name, "strip"),
+        "cc1plus": __tool_path(toolchain_name, "cc1plus")
+    }
+
+def runai_cc_autoconf_configurator(impl):
+    # This configuration was heavily inspired (copied) for bazel native cc toolchain
+    # configuration.
+    # when updating bazel version, we need to check if this was changed and update accordignly
+    # https://github.com/bazelbuild/bazel/blob/539f0de204793bb13579ef280338beb2d8835a89/tools/cpp/cc_configure.bzl#L93-L154
+    MSVC_ENVVARS = [
+        "BAZEL_VC",
+        "BAZEL_VC_FULL_VERSION",
+        "BAZEL_VS",
+        "BAZEL_WINSDK_FULL_VERSION",
+        "VS90COMNTOOLS",
+        "VS100COMNTOOLS",
+        "VS110COMNTOOLS",
+        "VS120COMNTOOLS",
+        "VS140COMNTOOLS",
+        "VS150COMNTOOLS",
+        "VS160COMNTOOLS",
+        "TMP",
+        "TEMP",
+    ]
+    return repository_rule(
+        environ = [
+            "ABI_LIBC_VERSION",
+            "ABI_VERSION",
+            "BAZEL_COMPILER",
+            "BAZEL_HOST_SYSTEM",
+            "BAZEL_CXXOPTS",
+            "BAZEL_LINKOPTS",
+            "BAZEL_LINKLIBS",
+            "BAZEL_LLVM_COV",
+            "BAZEL_PYTHON",
+            "BAZEL_SH",
+            "BAZEL_TARGET_CPU",
+            "BAZEL_TARGET_LIBC",
+            "BAZEL_TARGET_SYSTEM",
+            "BAZEL_USE_CPP_ONLY_TOOLCHAIN",
+            "BAZEL_USE_XCODE_TOOLCHAIN",
+            "BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN",
+            "BAZEL_USE_LLVM_NATIVE_COVERAGE",
+            "BAZEL_LLVM",
+            "BAZEL_IGNORE_SYSTEM_HEADERS_VERSIONS",
+            "USE_CLANG_CL",
+            "CC",
+            "CC_CONFIGURE_DEBUG",
+            "CC_TOOLCHAIN_NAME",
+            "CPLUS_INCLUDE_PATH",
+            "DEVELOPER_DIR",
+            "GCOV",
+            "HOMEBREW_RUBY_PATH",
+            "SYSTEMROOT",
+            "USER",
+        ] + MSVC_ENVVARS,
+        implementation = impl,
+        configure = True,
+    )
+
+def runai_cc_autoconf_default_impl(ctx):
+    tools = runai_crosstool_tools("")
+    return cc_autoconf_impl(ctx, overriden_tools = tools)
+
+def runai_cc_configure_toolchain(toolchain_name, impl = cc_autoconf_impl):
+    """A C++ configuration rules that generate the crosstool file."""
+
+    cc_autoconf_toolchains(name = toolchain_name + "_toolchains")
+
+    runai_cc_autoconf = runai_cc_autoconf_configurator(impl)
+    runai_cc_autoconf(name = toolchain_name)
+
+    native.bind(name = "cc_toolchain", actual = "@" + toolchain_name + "//:toolchain")
+    native.register_toolchains(
+        # Use register_toolchain's target pattern expansion to register all toolchains in the package.
+        "@" + toolchain_name + "_toolchains//:all",
+    )
+
+def runai_cc_autoconf_impl_x86(ctx):
+    tools = runai_crosstool_tools("")
+    return cc_autoconf_impl(ctx, overriden_tools = tools)
+
+def runai_cc_autoconf_impl_arm64(ctx):
+    tools = runai_crosstool_tools("aarch64-linux-gnu")
+    return cc_autoconf_impl(ctx, overriden_tools = tools) 


### PR DESCRIPTION
In this change we introduce `aarch64` support.

Many machines, for deep learning usage, are using ARM64 CPUs (NVIDIA GH200 for example).
In order to run on such machines we need to compile our CPP code to `aarch64` architecture.

This PR introduce such compilation.

Disclaimer:
* Host machine:
  * On `x86_64` you can build both for `x86_64` (`make build`) and cross compile to `aarch64` (`make build_aarch64`)
  * On `aarch64` you can only build natively to `aarch64` (`make build`)
* This PR assume `x86_64` host run the CI