### PR TITLE
Dynamically link streamers3 libz

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -86,7 +86,7 @@ RUN curl -fsSL -o zlib-1.3.1.tar.gz https://github.com/madler/zlib/releases/down
     RANLIB=/usr/bin/x86_64-linux-gnu-ranlib \
     CC=/usr/bin/x86_64-linux-gnu-gcc \
     NM=/usr/bin/x86_64-linux-gnu-nm \
-    ./configure --static --prefix=/opt/x86_64-zlib && \
+    ./configure --static --shared --prefix=/opt/x86_64-zlib && \
         make -j4 > /dev/null && \
         make install > /dev/null && \
         make clean > /dev/null && \
@@ -97,7 +97,7 @@ RUN curl -fsSL -o zlib-1.3.1.tar.gz https://github.com/madler/zlib/releases/down
     RANLIB=/usr/bin/aarch64-linux-gnu-ranlib \
     CC=/usr/bin/aarch64-linux-gnu-gcc \
     NM=/usr/bin/aarch64-linux-gnu-nm \
-    ./configure --static --prefix=/opt/aarch64-zlib && \
+    ./configure --static --shared --prefix=/opt/aarch64-zlib && \
         make -j4 > /dev/null && \
         make install > /dev/null && \
         make clean > /dev/null && \

--- a/cpp/WORKSPACE
+++ b/cpp/WORKSPACE
@@ -23,6 +23,8 @@ cc_library(
     hdrs = glob(["*aws/include/**/*.*"]),
     includes = ["$(BASE_PATH)-aws/include"],
     linkopts = [
+        "-L/opt/$(BASE_PATH)-zlib/lib",
+        "-lz",
         "-L/opt/$(BASE_PATH)-aws/lib",
         "-lpthread",
         "-l:libaws-cpp-sdk-s3-crt.a",


### PR DESCRIPTION
Given the following issue: https://github.com/run-ai/runai-model-streamer/issues/32

Arised after this PR: https://github.com/run-ai/runai-model-streamer/pull/27

In this PR we revert a small change and dynamically link to libz installed on the host.