### PR TITLE
support ca_bundle and AWS_CA_BUNDLE

### DIFF
--- a/cpp/common/response_code/response_code.cc
+++ b/cpp/common/response_code/response_code.cc
@@ -33,6 +33,7 @@ constexpr std::array<const char *, static_cast<size_t>(ResponseCode::__Max)> __m
     "Invalid request parameters",
     "Empty request parameters",
     "Streamer is handling previous request",
+    "CA bundle file not found",
     "Unknown Error"
 };
 

--- a/cpp/common/response_code/response_code.h
+++ b/cpp/common/response_code/response_code.h
@@ -19,6 +19,7 @@ enum class ResponseCode : int
     InvalidParameterError,
     EmptyRequestError,
     BusyError,
+    CaFileNotFound,
     UnknownError,
     __Max,
 };

--- a/cpp/common/response_code/response_code_test.cc
+++ b/cpp/common/response_code/response_code_test.cc
@@ -23,12 +23,13 @@ TEST(Response, Description)
         "Invalid request parameters",
         "Empty request parameters",
         "Streamer is handling previous request",
+        "CA bundle file not found",
         "Unknown Error"
     };
 
     // errors
 
-    for (auto response_code : {ResponseCode::FileAccessError, ResponseCode::EofError, ResponseCode::InvalidParameterError, ResponseCode::EmptyRequestError, ResponseCode::BusyError, ResponseCode::UnknownError, ResponseCode::FinishedError, ResponseCode::S3NotSupported, ResponseCode::GlibcPrerequisite, ResponseCode::InsufficientFdLimit} )
+    for (auto response_code : {ResponseCode::FileAccessError, ResponseCode::EofError, ResponseCode::InvalidParameterError, ResponseCode::EmptyRequestError, ResponseCode::BusyError, ResponseCode::UnknownError, ResponseCode::FinishedError, ResponseCode::S3NotSupported, ResponseCode::GlibcPrerequisite, ResponseCode::InsufficientFdLimit, ResponseCode::CaFileNotFound} )
     {
         std::string str = description(static_cast<int>(response_code));
 

--- a/cpp/s3/client/BUILD
+++ b/cpp/s3/client/BUILD
@@ -9,6 +9,8 @@ runai_cc_auto_library(
         "//common/responder",
         "//common/range",
         "//common/s3_credentials",
+        "//common/exception",
         "//utils/env",
+        "//utils/fd",
     ],
 )

--- a/cpp/s3/s3.h
+++ b/cpp/s3/s3.h
@@ -34,7 +34,7 @@ namespace runai::llm::streamer::impl::s3
 {
 
 // create client
-extern "C" void * runai_create_s3_client(const common::s3::StorageUri_C & uri,  const common::s3::Credentials_C & credentials);
+extern "C" common::ResponseCode runai_create_s3_client(const common::s3::StorageUri_C & uri,  const common::s3::Credentials_C & credentials, void ** client);
 // destroy client
 extern "C" void runai_remove_s3_client(void * client);
 // asynchronous read

--- a/cpp/s3/s3_mock/s3_mock.cc
+++ b/cpp/s3/s3_mock/s3_mock.cc
@@ -29,19 +29,18 @@ void runai_mock_s3_set_response_time_ms(unsigned milliseconds)
     __mock_response_time_ms = milliseconds;
 }
 
-void * runai_create_s3_client(const common::s3::StorageUri_C & uri, const common::s3::Credentials_C & credentials)
+common::ResponseCode runai_create_s3_client(const common::s3::StorageUri_C & uri, const common::s3::Credentials_C & credentials, void ** client)
 {
     const auto guard = std::unique_lock<std::mutex>(__mutex);
 
-    void * client;
     do
     {
-        client = reinterpret_cast<void *>(utils::random::number());
+        *client = reinterpret_cast<void *>(utils::random::number());
     } while (__mock_clients.count(client));
 
     __mock_clients.insert(client);
     __mock_index[client] = 0;
-    return client;
+    return common::ResponseCode::Success;
 }
 
 void runai_remove_s3_client(void * client)

--- a/cpp/s3/s3_mock/s3_mock.h
+++ b/cpp/s3/s3_mock/s3_mock.h
@@ -8,7 +8,7 @@
 namespace runai::llm::streamer::common::s3
 {
 
-extern "C" void * runai_create_s3_client(const common::s3::StorageUri_C & uri,  const common::s3::Credentials_C & credentials);
+extern "C" common::ResponseCode runai_create_s3_client(const common::s3::StorageUri_C & uri,  const common::s3::Credentials_C & credentials, void ** client);
 extern "C" void runai_remove_s3_client(void * client);
 extern "C" common::ResponseCode  runai_async_read_s3_client(void * client, unsigned num_ranges, common::Range * ranges, size_t chunk_bytesize, char * buffer);
 extern "C" common::ResponseCode  runai_async_response_s3_client(void * client, unsigned * index /* output parameter */);

--- a/cpp/utils/fd/fd.cc
+++ b/cpp/utils/fd/fd.cc
@@ -251,4 +251,10 @@ void Fd::write(const std::string & path, const std::vector<uint8_t> & data, int 
     fd.write(data.data(), data.size());
 }
 
+bool Fd::exists(const std::string & path)
+{
+    return ::access(path.c_str(), F_OK) != -1;
+}
+
+
 } // namespace runai::llm::streamer::utils

--- a/cpp/utils/fd/fd.h
+++ b/cpp/utils/fd/fd.h
@@ -49,6 +49,8 @@ struct Fd
     std::vector<uint8_t> read(size_t size, Read mode = Read::Exactly);
     void write(const std::vector<uint8_t> & data);
 
+    static bool exists(const std::string & path);
+
     // read the entire file - used for testing
 
     static std::vector<uint8_t> read(const std::string & path);

--- a/docs/src/env-vars.md
+++ b/docs/src/env-vars.md
@@ -61,6 +61,16 @@ String
 
 Default S3 url endpoint
 
+### AWS_CA_BUNDLE
+
+Specifies the path to a certificate bundle to use for HTTPS certificate validation.
+
+If defined, this environment variable overrides the value for the profile setting ca_bundle.
+
+#### Values accepted
+
+String
+
 ### RUNAI_STREAMER_S3_USE_VIRTUAL_ADDRESSING
 
 Controls parsing the url endpoint for reading from object store 

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -36,6 +36,12 @@ By default, the streamer performs authentication via boto3 to obtain credentials
 
 This is the recommended way to load tensors from AWS S3 storage
 
+###### HTTPS certificate
+
+Custom certificates file can be passed using `AWS_CA_BUNDLE=path/to/ca_file`
+
+The file path can also be configured in `~/.aws/config` file with `ca_bundle = /path/to/ca_file`, in case the authentication is via boto3 (`RUNAI_STREAMER_NO_BOTO3_SESSION=0` which is the default)
+
 ###### Authentication via AWS CPP SDK 
 
 The boto3 authentication can be disabled by setting `RUNAI_STREAMER_NO_BOTO3_SESSION=1`.

--- a/py/runai_model_streamer_s3/runai_model_streamer_s3/credentials/credentials.py
+++ b/py/runai_model_streamer_s3/runai_model_streamer_s3/credentials/credentials.py
@@ -3,6 +3,8 @@ from typing import Tuple, Dict, Optional
 import os
 import boto3
 
+AWS_CA_BUNDLE_ENV = "AWS_CA_BUNDLE"
+
 class S3Credentials:
     def __init__(
         self,
@@ -51,4 +53,10 @@ def get_credentials(credentials: Optional[S3Credentials] = None) -> Tuple[boto3.
         endpoint=credentials.endpoint if credentials else None, 
     )
 
+    # set ca_bundle if exists and AWS_CA_BUNDLE is undefined
+    if AWS_CA_BUNDLE_ENV not in os.environ:
+        ca_bundle = session._session.get_config_variable("ca_bundle")
+        if ca_bundle is not None:
+            os.environ.setdefault(AWS_CA_BUNDLE_ENV, ca_bundle)
+ 
     return session, new_credentials


### PR DESCRIPTION
Fix issue #46 

The AWS S3 C++ SDK requires to set the ca bundle file in the client's configuration.
If `AWS_CA_BUNDLE` is defined, the value is set in the configuration.

In order to support `ca_bundle` field in .aws/config file we do the following:
If a boto3 session is created, the session is checked for the ca bundle file. If defined, and `AWS_CA_BUNDLE` is not defined, `AWS_CA_BUNDLE` is set to that value.