### PR TITLE
WIP: Multiple files

### DIFF
--- a/cpp/common/path/BUILD
+++ b/cpp/common/path/BUILD
@@ -1,0 +1,8 @@
+load("//:rules.bzl", "runai_cc_auto_library")
+
+runai_cc_auto_library(
+    name = "path",
+    deps = [
+        "//common/storage_uri",
+    ],
+)

--- a/cpp/common/path/path.cc
+++ b/cpp/common/path/path.cc
@@ -1,0 +1,11 @@
+#include "common/path/path.h"
+
+namespace runai::llm::streamer::common::s3
+{
+
+Path::Path(const StorageUri_C & path, unsigned index) :
+    uri(path),
+    index(index)
+{}
+
+}; //namespace runai::llm::streamer::common::s3

--- a/cpp/common/path/path.h
+++ b/cpp/common/path/path.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "common/storage_uri/storage_uri.h"
+
+namespace runai::llm::streamer::common::s3
+{
+
+struct Path
+{
+    Path() = default;
+    Path(const StorageUri_C & path, unsigned index);
+
+    // File bucket and path
+    common::s3::StorageUri_C uri;
+
+    // Index of file in the original files list
+    unsigned index;
+};
+
+}; //namespace runai::llm::streamer::common::s3

--- a/cpp/common/responder/responder.cc
+++ b/cpp/common/responder/responder.cc
@@ -113,7 +113,7 @@ void Responder::cancel()
 void Responder::stop()
 {
     {
-        LOG(ERROR) << "stopping";
+        LOG(DEBUG) << "stopping";
         const auto guard = std::unique_lock<std::mutex>(_mutex);
         _stopped = true;
     }

--- a/cpp/common/responder/responder.h
+++ b/cpp/common/responder/responder.h
@@ -29,6 +29,8 @@ struct Responder
 
     ~Responder();
 
+    void increment(unsigned running);
+
     Response pop();
 
     void push(Response && response);

--- a/cpp/common/response/response.cc
+++ b/cpp/common/response/response.cc
@@ -4,9 +4,14 @@
 namespace runai::llm::streamer::common
 {
 
-Response::Response(unsigned index, ResponseCode ret) :
+Response::Response(unsigned file_index, unsigned index, common::ResponseCode ret) :
+    file_index(file_index),
     index(index),
     ret(ret)
+{}
+
+Response::Response(unsigned index, ResponseCode ret) :
+    Response(0, index, ret)
 {}
 
 Response::Response(unsigned index) : Response(index, ResponseCode::Success)

--- a/cpp/common/response/response.cc
+++ b/cpp/common/response/response.cc
@@ -33,7 +33,7 @@ bool Response::operator!=(const ResponseCode other)
 
 std::ostream & operator<<(std::ostream & os, const Response & response)
 {
-    return os << "request index: " << response.index << " Response code: " << response.ret;
+    return os << "File index: " << response.file_index << " Request index: " << response.index << " Response code: " << response.ret;
 }
 
 }; // namespace runai::llm::streamer::common

--- a/cpp/common/response/response.h
+++ b/cpp/common/response/response.h
@@ -10,6 +10,7 @@ namespace runai::llm::streamer::common
 
 struct Response
 {
+    Response(unsigned file_index, unsigned index, common::ResponseCode ret);
     Response(unsigned index, common::ResponseCode ret);
     Response(unsigned index);
     Response(common::ResponseCode ret);
@@ -18,8 +19,12 @@ struct Response
     bool operator==(const common::ResponseCode other);
     bool operator!=(const common::ResponseCode other);
 
+    // index of file
+    unsigned file_index;
+
     // index of sub request
     unsigned index;
+
 
     // response code
     common::ResponseCode ret;

--- a/cpp/common/s3_wrapper/BUILD
+++ b/cpp/common/s3_wrapper/BUILD
@@ -6,6 +6,7 @@ runai_cc_auto_library(
         "//common/storage_uri",
         "//common/s3_credentials",
         "//common/response",
+        "//common/path",
         "//common/range",
         "//common/exception",
         "//utils/dylib",

--- a/cpp/common/s3_wrapper/s3_wrapper.cc
+++ b/cpp/common/s3_wrapper/s3_wrapper.cc
@@ -113,10 +113,11 @@ void * S3ClientWrapper::create_client(unsigned file_index, const StorageUri & ur
     return client;
 }
 
-ResponseCode S3ClientWrapper::async_read(std::vector<Range>& ranges, size_t chunk_bytesize, char * buffer)
+ResponseCode S3ClientWrapper::async_read(const Params & params, std::vector<Range>& ranges, size_t chunk_bytesize, char * buffer)
 {
-    static auto _s3_async_read = _s3_dylib->dlsym<ResponseCode(*)(void *, unsigned, Range*, size_t, char *)>("runai_async_read_s3_client");
-    return _s3_async_read(_s3_client, ranges.size(), ranges.data(), chunk_bytesize, buffer);
+    static auto _s3_async_read = _s3_dylib->dlsym<ResponseCode(*)(void *, const Path &, unsigned, Range*, size_t, char *)>("runai_async_read_s3_client");
+    const Path s3_path(*params.uri, params.file_index);
+    return _s3_async_read(_s3_client, s3_path, ranges.size(), ranges.data(), chunk_bytesize, buffer);
     return common::ResponseCode::Success;
 }
 
@@ -124,8 +125,8 @@ Response S3ClientWrapper::async_read_response()
 {
     Response r(common::ResponseCode::Success);
 
-    static auto _s3_async_response = _s3_dylib->dlsym<ResponseCode(*)(void *, unsigned*)>("runai_async_response_s3_client");
-    r.ret = _s3_async_response(_s3_client, &r.index);
+    static auto _s3_async_response = _s3_dylib->dlsym<ResponseCode(*)(void *, unsigned*, unsigned*)>("runai_async_response_s3_client");
+    r.ret = _s3_async_response(_s3_client, &r.file_index, &r.index);
     return r;
 }
 

--- a/cpp/common/s3_wrapper/s3_wrapper.h
+++ b/cpp/common/s3_wrapper/s3_wrapper.h
@@ -23,16 +23,18 @@ struct S3ClientWrapper
          Params()
          {}
 
-         Params(std::shared_ptr<StorageUri> uri, const Credentials & credentials) :
+         Params(unsigned file_index, std::shared_ptr<StorageUri> uri, const Credentials & credentials) :
+            file_index(file_index),
             uri(uri),
             credentials(credentials)
          {}
 
-         Params(std::shared_ptr<StorageUri> uri) : Params(uri, Credentials())
+         Params(std::shared_ptr<StorageUri> uri) : Params(0, uri, Credentials())
          {}
 
          bool valid() const { return (uri.get() != nullptr); }
 
+         unsigned file_index;
          std::shared_ptr<StorageUri> uri;
          Credentials credentials;
       };
@@ -59,7 +61,7 @@ struct S3ClientWrapper
       static constexpr size_t default_chunk_bytesize = 8 * 1024 * 1024;
 
  private:
-      void * create_client(const StorageUri & uri, const Credentials & credentials);
+      void * create_client(unsigned file_index, const StorageUri & uri, const Credentials & credentials);
       static std::shared_ptr<utils::Dylib> open_s3();
       static std::shared_ptr<utils::Dylib> open_s3_impl();
 

--- a/cpp/common/s3_wrapper/s3_wrapper.h
+++ b/cpp/common/s3_wrapper/s3_wrapper.h
@@ -47,7 +47,7 @@ struct S3ClientWrapper
       // ranges - list of sub ranges
       // chunk_bytesize - size of chunk for reading in multi parts (minimal size is 5 MB)
 
-      ResponseCode async_read(std::vector<Range>& ranges, size_t chunk_bytesize, char * buffer);
+      ResponseCode async_read(const Params & params, std::vector<Range>& ranges, size_t chunk_bytesize, char * buffer);
       Response async_read_response();
 
       // stop - stops the responder of each S3 client, in order to notify callers which sent a request and are waiting for a response

--- a/cpp/common/s3_wrapper/s3_wrapper_test.cc
+++ b/cpp/common/s3_wrapper/s3_wrapper_test.cc
@@ -11,6 +11,7 @@ namespace runai::llm::streamer::common::s3
 struct S3WrappertTest : ::testing::Test
 {
     S3WrappertTest() :
+        index(utils::random::number()),
         uri("s3://" + utils::random::string() + "/" + utils::random::string()),
         credentials(
             (utils::random::boolean() ? utils::random::string().c_str() : nullptr),
@@ -18,7 +19,7 @@ struct S3WrappertTest : ::testing::Test
             (utils::random::boolean() ? utils::random::string().c_str() : nullptr),
             (utils::random::boolean() ? utils::random::string().c_str() : nullptr),
             (utils::random::boolean() ? utils::random::string().c_str() : nullptr)),
-        params(std::make_shared<StorageUri>(uri), credentials)
+        params(index, std::make_shared<StorageUri>(uri), credentials)
     {}
 
     void TearDown() override
@@ -26,6 +27,7 @@ struct S3WrappertTest : ::testing::Test
         S3ClientWrapper::shutdown();
     }
 
+    unsigned index;
     StorageUri uri;
     Credentials credentials;
     S3ClientWrapper::Params params;

--- a/cpp/common/s3_wrapper/s3_wrapper_test.cc
+++ b/cpp/common/s3_wrapper/s3_wrapper_test.cc
@@ -56,7 +56,7 @@ TEST_F(S3WrappertTest, Read)
 {
     S3ClientWrapper wrapper(params);
     std::vector<Range> ranges;
-    auto response_code = wrapper.async_read(ranges, utils::random::number<size_t>(), nullptr);
+    auto response_code = wrapper.async_read(params, ranges, utils::random::number<size_t>(), nullptr);
     EXPECT_EQ(response_code, common::ResponseCode::Success);
 }
 
@@ -68,7 +68,7 @@ TEST_F(S3WrappertTest, Cleanup)
     {
         S3ClientWrapper wrapper(params);
         std::vector<Range> ranges;
-        wrapper.async_read(ranges, utils::random::number<size_t>(), nullptr);
+        wrapper.async_read(params, ranges, utils::random::number<size_t>(), nullptr);
 
         EXPECT_EQ(verify_mock(), 1);
 

--- a/cpp/common/storage_uri/storage_uri.cc
+++ b/cpp/common/storage_uri/storage_uri.cc
@@ -42,7 +42,7 @@ std::ostream & operator<<(std::ostream & os, const StorageUri & uri)
 StorageUri_C::StorageUri_C(const StorageUri & uri) :
     bucket(uri.bucket.c_str()),
     path(uri.path.c_str()),
-    endpoint(uri.endpoint.c_str())
+    endpoint(uri.endpoint.empty() ? nullptr : uri.endpoint.c_str())
 {}
 
 }; // namespace runai::llm::streamer::common::s3

--- a/cpp/s3/client/BUILD
+++ b/cpp/s3/client/BUILD
@@ -9,6 +9,7 @@ runai_cc_auto_library(
         "//common/responder",
         "//common/range",
         "//common/s3_credentials",
+        "//common/path",
         "//common/exception",
         "//utils/env",
         "//utils/fd",

--- a/cpp/s3/client/BUILD
+++ b/cpp/s3/client/BUILD
@@ -9,6 +9,7 @@ runai_cc_auto_library(
         "//common/responder",
         "//common/range",
         "//common/s3_credentials",
+        "//common/s3_wrapper",
         "//common/path",
         "//common/exception",
         "//utils/env",

--- a/cpp/s3/client/client.cc
+++ b/cpp/s3/client/client.cc
@@ -165,7 +165,7 @@ common::ResponseCode S3Client::async_read(const common::s3::Path & object_path, 
         _responder->increment(num_ranges);
     }
 
-    ASSERT((object_path.uri.endpoint == nullptr) || (_endpoint.has_value() && _endpoint.value() == std::string(object_path.uri.endpoint))) << "Attempting to reuse client with a different endpoint " << object_path.uri.endpoint;
+    ASSERT((!_endpoint.has_value()) || (object_path.uri.endpoint == nullptr) || (_endpoint.has_value() && _endpoint.value() == std::string(object_path.uri.endpoint))) << "Attempting to reuse client with a different endpoint " << object_path.uri.endpoint;
     ASSERT(object_path.uri.bucket == _bucket_name) << "Attempting to reuse client of bucket " << _bucket_name << " with a different bucket " << object_path.uri.bucket;
 
     Aws::String bucket_name(object_path.uri.bucket);

--- a/cpp/s3/client/client.cc
+++ b/cpp/s3/client/client.cc
@@ -17,7 +17,7 @@
 namespace runai::llm::streamer::impl::s3
 {
 
-S3ClientBase::S3ClientBase(const common::s3::StorageUri_C & uri) : S3ClientBase(uri, common::s3::Credentials())
+S3ClientBase::S3ClientBase(const common::s3::Path & path) : S3ClientBase(path, common::s3::Credentials())
 {}
 
 std::optional<Aws::String> convert(const char * input) {
@@ -28,9 +28,10 @@ std::optional<Aws::String> convert(const char * input) {
     return std::nullopt;
 }
 
-S3ClientBase::S3ClientBase(const common::s3::StorageUri_C & uri, const common::s3::Credentials_C & credentials) :
-    _bucket_name(uri.bucket),
-    _path(uri.path),
+S3ClientBase::S3ClientBase(const common::s3::Path & path, const common::s3::Credentials_C & credentials) :
+    _bucket_name(path.uri.bucket),
+    _path(path.uri.path),
+    _path_index(path.index),
     _key(convert(credentials.access_key_id)),
     _secret(convert(credentials.secret_access_key)),
     _token(convert(credentials.session_token)),
@@ -45,10 +46,13 @@ std::string S3ClientBase::bucket() const
     return std::string(_bucket_name.c_str(), _bucket_name.size());
 }
 
-void S3ClientBase::path(const char * path, unsigned path_index)
+void S3ClientBase::path(const common::s3::Path & path)
 {
-    _path = Aws::String(path);
-    _path_index = path_index;
+    ASSERT(path.uri.bucket == _bucket_name) << "Attempting to reuse client of bucket " << _bucket_name << " with a different bucket " << path.uri.bucket;
+    ASSERT((path.uri.endpoint == nullptr) || (_endpoint.has_value() && _endpoint.value() == std::string(path.uri.endpoint))) << "Attempting to reuse client with a different endpoint " << path.uri.endpoint;
+    LOG(DEBUG) << "Setting s3 client path " << path.uri.path << "bucket " << path.uri.bucket << " and index to " << path.index;
+    _path = Aws::String(path.uri.path);
+    _path_index = path.index;
 }
 
 bool S3ClientBase::verify_credentials_member(const std::optional<Aws::String>& member, const char* value, const char * name) const
@@ -84,26 +88,27 @@ bool S3ClientBase::verify_credentials(const common::s3::Credentials_C & credenti
             verify_credentials_member(_endpoint, credentials.endpoint, "endpoint"));
 }
 
-S3Client::S3Client(const common::s3::StorageUri_C & uri) : S3Client(uri, common::s3::Credentials())
+S3Client::S3Client(const common::s3::Path & path) : S3Client(path, common::s3::Credentials())
 {}
 
-S3Client::S3Client(const common::s3::StorageUri_C & uri, const common::s3::Credentials_C & credentials) :
-    S3ClientBase(uri, credentials),
-    _stop(false)
+S3Client::S3Client(const common::s3::Path & path, const common::s3::Credentials_C & credentials) :
+    S3ClientBase(path, credentials),
+    _stop(false),
+    _responder(nullptr)
 {
     if (_endpoint.has_value()) // endpoint passed as parameter by user application
     {
         LOG(DEBUG) <<"Using credentials endpoint " << credentials.endpoint;
         _client_config.config.endpointOverride = _endpoint.value();
     }
-    else if (uri.endpoint != nullptr) // endpoint passed as environment variable
+    else if (path.uri.endpoint != nullptr) // endpoint passed as environment variable
     {
         bool override_endpoint_flag = utils::getenv<bool>("RUNAI_STREAMER_OVERRIDE_ENDPOINT_URL", true);
         if (override_endpoint_flag)
         {
-            _client_config.config.endpointOverride = Aws::String(uri.endpoint);
+            _client_config.config.endpointOverride = Aws::String(path.uri.endpoint);
         }
-        LOG(DEBUG) <<"Using environment variable endpoint " << uri.endpoint << (override_endpoint_flag ? " , using configuration parameter endpointOverride" : "");
+        LOG(DEBUG) <<"Using environment variable endpoint " << path.uri.endpoint << (override_endpoint_flag ? " , using configuration parameter endpointOverride" : "");
     }
 
     if (utils::try_getenv("RUNAI_STREAMER_S3_USE_VIRTUAL_ADDRESSING", _client_config.config.useVirtualAddressing))
@@ -194,7 +199,14 @@ common::ResponseCode S3Client::async_read(unsigned num_ranges, common::Range * r
         return common::ResponseCode::BusyError;
     }
 
-    _responder = std::make_shared<common::Responder>(num_ranges);
+    if (_responder == nullptr)
+    {
+        _responder = std::make_shared<common::Responder>(num_ranges);
+    }
+    else
+    {
+        _responder->increment(num_ranges);
+    }
 
     Aws::S3Crt::Model::GetObjectRequest request;
     request.SetBucket(_bucket_name);
@@ -238,7 +250,7 @@ common::ResponseCode S3Client::async_read(unsigned num_ranges, common::Range * r
                     return stream.release();
                 });
 
-            _client->GetObjectAsync(request, [responder = _responder, ir, counter, is_success](const Aws::S3Crt::S3CrtClient*, const Aws::S3Crt::Model::GetObjectRequest&,
+            _client->GetObjectAsync(request, [responder = _responder, file_index = _path_index, ir, counter, is_success](const Aws::S3Crt::S3CrtClient*, const Aws::S3Crt::Model::GetObjectRequest&,
                                                                             const Aws::S3Crt::Model::GetObjectOutcome& outcome,
                                                                             const std::shared_ptr<const Aws::Client::AsyncCallerContext>&) {
                 if (outcome.IsSuccess())
@@ -249,7 +261,7 @@ common::ResponseCode S3Client::async_read(unsigned num_ranges, common::Range * r
                     // note that unsuccessful attempts do not update the counter
                     if (running == 1)
                     {
-                        common::Response r(ir, common::ResponseCode::Success);
+                        common::Response r(file_index, ir, common::ResponseCode::Success);
                         responder->push(std::move(r));
                     }
                 }

--- a/cpp/s3/client/client.cc
+++ b/cpp/s3/client/client.cc
@@ -150,12 +150,6 @@ common::Response S3Client::async_read_response()
 // aynchronously read consecutive ranges, producing a Response object per range in the ranges vector
 common::ResponseCode S3Client::async_read(const common::s3::Path & object_path, unsigned num_ranges, common::Range * ranges, size_t chunk_bytesize, char * buffer)
 {
-    if (_responder != nullptr && !_responder->finished())
-    {
-        LOG(ERROR) << "S3 client has not finished the previous async request";
-        return common::ResponseCode::BusyError;
-    }
-
     if (_responder == nullptr)
     {
         _responder = std::make_shared<common::Responder>(num_ranges);

--- a/cpp/s3/client/client.cc
+++ b/cpp/s3/client/client.cc
@@ -45,9 +45,10 @@ std::string S3ClientBase::bucket() const
     return std::string(_bucket_name.c_str(), _bucket_name.size());
 }
 
-void S3ClientBase::path(const char * path)
+void S3ClientBase::path(const char * path, unsigned path_index)
 {
     _path = Aws::String(path);
+    _path_index = path_index;
 }
 
 bool S3ClientBase::verify_credentials_member(const std::optional<Aws::String>& member, const char* value, const char * name) const

--- a/cpp/s3/client/client.h
+++ b/cpp/s3/client/client.h
@@ -10,6 +10,7 @@
 #include "common/path/path.h"
 #include "common/storage_uri/storage_uri.h"
 #include "common/s3_credentials/s3_credentials.h"
+#include "common/s3_wrapper/s3_wrapper.h"
 #include "common/responder/responder.h"
 #include "common/response/response.h"
 #include "common/range/range.h"
@@ -23,17 +24,14 @@ struct S3ClientBase
 
     S3ClientBase(const common::s3::Path & path, const common::s3::Credentials_C & credentials);
 
+    // get client's bucket name
     std::string bucket() const;
-
-    void path(const common::s3::Path & path);
 
     // verify that clien's credentials have not change
     bool verify_credentials(const common::s3::Credentials_C & credentials) const;
 
  protected:
     const Aws::String _bucket_name;
-    Aws::String _path;
-    unsigned _path_index; // path identifer to be returned in response instead of the path string
     const std::optional<Aws::String> _key;
     const std::optional<Aws::String> _secret;
     const std::optional<Aws::String> _token;
@@ -51,9 +49,7 @@ struct S3Client : S3ClientBase
 
     S3Client(const common::s3::Path & path, const common::s3::Credentials_C & credentials);
 
-    common::ResponseCode read(size_t offset, size_t bytesize, char * buffer);
-
-    common::ResponseCode async_read(unsigned num_ranges, common::Range * ranges, size_t chunk_bytesize, char * buffer);
+    common::ResponseCode async_read(const common::s3::Path & path, unsigned num_ranges, common::Range * ranges, size_t chunk_bytesize, char * buffer);
 
     common::Response async_read_response();
 
@@ -63,7 +59,6 @@ struct S3Client : S3ClientBase
     void stop();
 
     using S3ClientBase::bucket;
-    using S3ClientBase::path;
     using S3ClientBase::verify_credentials;
 
  private:

--- a/cpp/s3/client/client.h
+++ b/cpp/s3/client/client.h
@@ -24,7 +24,7 @@ struct S3ClientBase
 
     std::string bucket() const;
 
-    void path(const char * path);
+    void path(const char * path, unsigned path_index);
 
     // verify that clien's credentials have not change
     bool verify_credentials(const common::s3::Credentials_C & credentials) const;
@@ -32,6 +32,7 @@ struct S3ClientBase
  protected:
     const Aws::String _bucket_name;
     Aws::String _path;
+    unsigned _path_index; // path identifer to be returned in response instead of the path string
     const std::optional<Aws::String> _key;
     const std::optional<Aws::String> _secret;
     const std::optional<Aws::String> _token;

--- a/cpp/s3/client/client.h
+++ b/cpp/s3/client/client.h
@@ -7,6 +7,7 @@
 
 #include "s3/client_configuration/client_configuration.h"
 
+#include "common/path/path.h"
 #include "common/storage_uri/storage_uri.h"
 #include "common/s3_credentials/s3_credentials.h"
 #include "common/responder/responder.h"
@@ -18,13 +19,13 @@ namespace runai::llm::streamer::impl::s3
 
 struct S3ClientBase
 {
-    S3ClientBase(const common::s3::StorageUri_C & path);
+    S3ClientBase(const common::s3::Path & path);
 
-    S3ClientBase(const common::s3::StorageUri_C & path, const common::s3::Credentials_C & credentials);
+    S3ClientBase(const common::s3::Path & path, const common::s3::Credentials_C & credentials);
 
     std::string bucket() const;
 
-    void path(const char * path, unsigned path_index);
+    void path(const common::s3::Path & path);
 
     // verify that clien's credentials have not change
     bool verify_credentials(const common::s3::Credentials_C & credentials) const;
@@ -46,9 +47,9 @@ struct S3ClientBase
 
 struct S3Client : S3ClientBase
 {
-    S3Client(const common::s3::StorageUri_C & path);
+    S3Client(const common::s3::Path & path);
 
-    S3Client(const common::s3::StorageUri_C & path, const common::s3::Credentials_C & credentials);
+    S3Client(const common::s3::Path & path, const common::s3::Credentials_C & credentials);
 
     common::ResponseCode read(size_t offset, size_t bytesize, char * buffer);
 

--- a/cpp/s3/client_mgr/client_mgr.h
+++ b/cpp/s3/client_mgr/client_mgr.h
@@ -106,12 +106,12 @@ T* ClientMgr<T>::pop(const common::s3::Path & path, const common::s3::Credential
 
         auto & unused = mgr._bucket_unused_clients;
         bool is_bucket = path.uri.bucket == mgr._current_bucket;
+
         if (is_bucket)
         {
             while (!unused.empty())
             {
                 auto ptr = *unused.begin();
-                ptr->path(path);
                 unused.erase(unused.begin());
 
                 // Reuse client only if credentials have not changed

--- a/cpp/s3/client_mgr/client_mgr_test.cc
+++ b/cpp/s3/client_mgr/client_mgr_test.cc
@@ -21,18 +21,7 @@ struct Helper : S3ClientBase
     }
 
     using S3ClientBase::bucket;
-    using S3ClientBase::path;
     using S3ClientBase::verify_credentials;
-
-    const std::string & path() const
-    {
-        return _path;
-    }
-
-    unsigned path_index() const
-    {
-        return _path_index;
-    }
 
     const std::optional<std::string> & key()
     {
@@ -161,7 +150,6 @@ TEST_F(ClientMgrTest, Reuse_Client)
         const common::s3::Path s3_path(uri, index);
         Helper * helper = ClientMgr<Helper>::pop(s3_path, credentials);
         EXPECT_EQ(helper->bucket(), uri.bucket);
-        EXPECT_EQ(helper->path(), path);
         EXPECT_EQ(ClientMgr<Helper>::current_bucket(), uri.bucket);
         EXPECT_EQ(helper->key(), credentials.access_key_id);
         EXPECT_EQ(helper->secret(), credentials.secret_access_key);
@@ -218,7 +206,6 @@ TEST_F(ClientMgrTest, Credentials_Changed)
         const common::s3::Path s3_path(uri, utils::random::number());
         Helper * helper = ClientMgr<Helper>::pop(s3_path, new_credentials);
         EXPECT_EQ(helper->bucket(), uri.bucket);
-        EXPECT_EQ(helper->path(), path);
         EXPECT_EQ(ClientMgr<Helper>::current_bucket(), uri.bucket);
         EXPECT_EQ(helper->key(), new_credentials.access_key_id);
         EXPECT_EQ(helper->secret(), new_credentials.secret_access_key);
@@ -281,8 +268,6 @@ TEST_F(ClientMgrTest, Change_Bucket)
         EXPECT_EQ(ClientMgr<Helper>::unused(), 0);
 
         EXPECT_EQ(helper->bucket(), uri_.bucket);
-        EXPECT_EQ(helper->path(), path);
-        EXPECT_EQ(helper->path_index(), index);
         EXPECT_EQ(ClientMgr<Helper>::current_bucket(), uri_.bucket);
 
         EXPECT_EQ(ClientMgr<Helper>::size(), i + 1);

--- a/cpp/s3/s3.cc
+++ b/cpp/s3/s3.cc
@@ -22,12 +22,12 @@
 namespace runai::llm::streamer::impl::s3
 {
 
-common::ResponseCode runai_create_s3_client(const common::s3::StorageUri_C & uri, const common::s3::Credentials_C & credentials, void ** client)
+common::ResponseCode runai_create_s3_client(const common::s3::Path & path, const common::s3::Credentials_C & credentials, void ** client)
 {
     common::ResponseCode ret = common::ResponseCode::Success;
     try
     {
-        *client = static_cast<void *>(S3ClientMgr::pop(uri, credentials));
+        *client = static_cast<void *>(S3ClientMgr::pop(path, credentials));
     }
     catch(const common::Exception & e)
     {

--- a/cpp/s3/s3.cc
+++ b/cpp/s3/s3.cc
@@ -82,7 +82,7 @@ void runai_stop_s3_clients()
     }
 }
 
-common::ResponseCode  runai_async_read_s3_client(void * client, unsigned num_ranges, common::Range * ranges, size_t chunk_bytesize, char * buffer)
+common::ResponseCode runai_async_read_s3_client(void * client, const common::s3::Path & path, unsigned num_ranges, common::Range * ranges, size_t chunk_bytesize, char * buffer)
 {
     try
     {
@@ -92,7 +92,7 @@ common::ResponseCode  runai_async_read_s3_client(void * client, unsigned num_ran
             return common::ResponseCode::UnknownError;
         }
         auto ptr = static_cast<S3Client *>(client);
-        return ptr->async_read(num_ranges, ranges, chunk_bytesize, buffer);
+        return ptr->async_read(path, num_ranges, ranges, chunk_bytesize, buffer);
     }
     catch(const std::exception& e)
     {
@@ -101,7 +101,7 @@ common::ResponseCode  runai_async_read_s3_client(void * client, unsigned num_ran
     return common::ResponseCode::UnknownError;
 }
 
-common::ResponseCode runai_async_response_s3_client(void * client, unsigned * index)
+common::ResponseCode runai_async_response_s3_client(void * client, unsigned * file_index, unsigned * index)
 {
     try
     {
@@ -113,6 +113,7 @@ common::ResponseCode runai_async_response_s3_client(void * client, unsigned * in
         auto ptr = static_cast<S3Client *>(client);
         auto response = ptr->async_read_response();
         *index = response.index;
+        *file_index = response.file_index;
         return response.ret;
     }
     catch(const std::exception& e)

--- a/cpp/s3/s3.h
+++ b/cpp/s3/s3.h
@@ -38,9 +38,9 @@ extern "C" common::ResponseCode runai_create_s3_client(const common::s3::Path & 
 // destroy client
 extern "C" void runai_remove_s3_client(void * client);
 // asynchronous read
-extern "C" common::ResponseCode  runai_async_read_s3_client(void * client, unsigned num_ranges, common::Range * ranges, size_t chunk_bytesize, char * buffer);
+extern "C" common::ResponseCode  runai_async_read_s3_client(void * client, const common::s3::Path & path, unsigned num_ranges, common::Range * ranges, size_t chunk_bytesize, char * buffer);
 // wait for asynchronous read response
-extern "C" common::ResponseCode  runai_async_response_s3_client(void * client, unsigned * index /* output parameter */);
+extern "C" common::ResponseCode  runai_async_response_s3_client(void * client, unsigned * file_index /* output parameter */, unsigned * index /* output parameter */);
 // stop clients
 // Stops the responder of each client, in order to notify callers which sent a request and are waiting for a response
 extern "C" void runai_stop_s3_clients();

--- a/cpp/s3/s3.h
+++ b/cpp/s3/s3.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "common/storage_uri/storage_uri.h"
+#include "common/path/path.h"
 #include "common/s3_credentials/s3_credentials.h"
 #include "common/response/response.h"
 #include "common/range/range.h"
@@ -34,7 +34,7 @@ namespace runai::llm::streamer::impl::s3
 {
 
 // create client
-extern "C" common::ResponseCode runai_create_s3_client(const common::s3::StorageUri_C & uri,  const common::s3::Credentials_C & credentials, void ** client);
+extern "C" common::ResponseCode runai_create_s3_client(const common::s3::Path & path,  const common::s3::Credentials_C & credentials, void ** client);
 // destroy client
 extern "C" void runai_remove_s3_client(void * client);
 // asynchronous read

--- a/cpp/s3/s3_mock/BUILD
+++ b/cpp/s3/s3_mock/BUILD
@@ -7,7 +7,7 @@ runai_portable_so(
     ],
     deps = [
         "//common/response_code",
-        "//common/storage_uri",
+        "//common/path",
         "//common/s3_credentials",
         "//common/range",
         "//utils/env",

--- a/cpp/s3/s3_mock/s3_mock.h
+++ b/cpp/s3/s3_mock/s3_mock.h
@@ -8,10 +8,10 @@
 namespace runai::llm::streamer::common::s3
 {
 
-extern "C" common::ResponseCode runai_create_s3_client(const common::s3::Path & path,  const common::s3::Credentials_C & credentials, void ** client);
+extern "C" common::ResponseCode runai_create_s3_client(const common::s3::Path & path, const common::s3::Credentials_C & credentials, void ** client);
 extern "C" void runai_remove_s3_client(void * client);
-extern "C" common::ResponseCode  runai_async_read_s3_client(void * client, unsigned num_ranges, common::Range * ranges, size_t chunk_bytesize, char * buffer);
-extern "C" common::ResponseCode  runai_async_response_s3_client(void * client, unsigned * index /* output parameter */);
+extern "C" common::ResponseCode  runai_async_read_s3_client(void * client, const common::s3::Path & path, unsigned num_ranges, common::Range * ranges, size_t chunk_bytesize, char * buffer);
+extern "C" common::ResponseCode  runai_async_response_s3_client(void * client, unsigned * file_index /* output parameter */, unsigned * index /* output parameter */);
 extern "C" void runai_stop_s3_clients();
 extern "C" void runai_release_s3_clients();
 

--- a/cpp/s3/s3_mock/s3_mock.h
+++ b/cpp/s3/s3_mock/s3_mock.h
@@ -1,14 +1,14 @@
 #pragma once
 
 #include "common/range/range.h"
-#include "common/storage_uri/storage_uri.h"
+#include "common/path/path.h"
 #include "common/s3_credentials/s3_credentials.h"
 #include "common/response_code/response_code.h"
 
 namespace runai::llm::streamer::common::s3
 {
 
-extern "C" common::ResponseCode runai_create_s3_client(const common::s3::StorageUri_C & uri,  const common::s3::Credentials_C & credentials, void ** client);
+extern "C" common::ResponseCode runai_create_s3_client(const common::s3::Path & path,  const common::s3::Credentials_C & credentials, void ** client);
 extern "C" void runai_remove_s3_client(void * client);
 extern "C" common::ResponseCode  runai_async_read_s3_client(void * client, unsigned num_ranges, common::Range * ranges, size_t chunk_bytesize, char * buffer);
 extern "C" common::ResponseCode  runai_async_response_s3_client(void * client, unsigned * index /* output parameter */);

--- a/cpp/streamer/impl/assigner/BUILD
+++ b/cpp/streamer/impl/assigner/BUILD
@@ -1,0 +1,22 @@
+load("//:rules.bzl", "runai_cc_auto_library", "runai_cc_test")
+
+runai_cc_auto_library(
+    name = "assigner",
+    deps = [
+        "//streamer/impl/assigner/file_read_task",
+        "//streamer/impl/batches",
+        "//common/exception",
+        "//streamer/impl/config",
+        "//utils/logging"
+    ],
+)
+
+# runai_cc_test(
+#     name = "assigner_test",
+#     srcs = ["assigner_test.cc"],
+#     deps = [":assigner",
+#             "//utils/random",
+#             "//utils/temp/file",
+#             "//utils/scope_guard",
+#     ],
+# )

--- a/cpp/streamer/impl/assigner/BUILD
+++ b/cpp/streamer/impl/assigner/BUILD
@@ -12,12 +12,14 @@ runai_cc_auto_library(
     ],
 )
 
-# runai_cc_test(
-#     name = "assigner_test",
-#     srcs = ["assigner_test.cc"],
-#     deps = [":assigner",
-#             "//utils/random",
-#             "//utils/temp/file",
-#             "//utils/scope_guard",
-#     ],
-# )
+runai_cc_test(
+    name = "assigner_test",
+    srcs = ["assigner_test.cc"],
+    deps = [
+        ":assigner",
+        "//utils/random",
+        "//common/response_code",
+        "//common/exception",
+        "//utils/logging",
+    ],
+)

--- a/cpp/streamer/impl/assigner/BUILD
+++ b/cpp/streamer/impl/assigner/BUILD
@@ -6,6 +6,7 @@ runai_cc_auto_library(
         "//streamer/impl/assigner/file_read_task",
         "//streamer/impl/batches",
         "//common/exception",
+        "//common/storage_uri",
         "//streamer/impl/config",
         "//utils/logging"
     ],

--- a/cpp/streamer/impl/assigner/assigner.cc
+++ b/cpp/streamer/impl/assigner/assigner.cc
@@ -36,9 +36,9 @@ _num_workers(_config->concurrency)
         return; // Nothing to assign
     }
 
-    if (!(num_files == file_offsets.size() && num_files == bytesizes.size() && num_files == dsts.size()))
+    if (!(num_files == file_offsets.size() && num_files == bytesizes.size() && (num_files == dsts.size() || dsts.size() == 1)))
     {
-        LOG(ERROR) <<  "Input vector sizes mismatch";
+        LOG(ERROR) <<  "Input vector sizes mismatch " << num_files << " " << file_offsets.size() << " " << bytesizes.size() << " " << dsts.size();
         throw common::Exception(common::ResponseCode::InvalidParameterError);
     }
 

--- a/cpp/streamer/impl/assigner/assigner.cc
+++ b/cpp/streamer/impl/assigner/assigner.cc
@@ -1,0 +1,204 @@
+#include "streamer/impl/assigner/assigner.h"
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+#include <numeric> // For std::accumulate
+#include <cmath>   // For std::ceil
+#include <stdexcept> // For exceptions
+#include <limits>  // For numeric_limits
+#include <map>
+#include <utility>
+
+#include "common/exception/exception.h"
+
+#include "utils/logging/logging.h"
+
+namespace runai::llm::streamer::impl
+{
+
+MultiFileWorkloadAssigner::MultiFileWorkloadAssigner(
+        const std::vector<std::string> & paths,
+        const std::vector<size_t> & file_offsets,
+        const std::vector<size_t>&  bytesizes,
+        const std::vector<void*> & dsts,
+        std::shared_ptr<const Config> config) :
+_config(config),
+_num_workers(_config->concurrency)
+{
+    const size_t num_files = paths.size();
+    if (num_files == 0)
+    {
+        LOG(WARNING) << "MultiFileWorkloadAssigner: No files provided.";
+        return; // Nothing to assign
+    }
+
+    if (!(num_files == file_offsets.size() && num_files == bytesizes.size() && num_files == dsts.size()))
+    {
+        LOG(ERROR) <<  "Input vector sizes mismatch";
+        throw common::ResponseCode::InvalidParameterError;
+    }
+
+    // Calculate Total Workload
+    size_t total_bytes_to_read = 0;
+    for (size_t size : bytesizes) {
+        // Check for potential overflow if sizes are huge
+        if (total_bytes_to_read > std::numeric_limits<size_t>::max() - size)
+        {
+            LOG(ERROR) << "Total byte size calculation overflow";
+                throw common::ResponseCode::InvalidParameterError;
+        }
+        total_bytes_to_read += size;
+    }
+
+    if (total_bytes_to_read == 0)
+    {
+        LOG(WARNING) << "Total bytes to read is zero.";
+        return; // Nothing to assign
+    }
+
+    // Determine Workload per Worker
+    const size_t base_bytes_per_worker = total_bytes_to_read / _num_workers;
+    const size_t remainder_bytes = total_bytes_to_read % _num_workers;
+    LOG(DEBUG) << "Total bytes: " << total_bytes_to_read
+                << ", Workers: " << _num_workers
+                << ", Base bytes/worker: " << base_bytes_per_worker
+                << ", Remainder: " << remainder_bytes;
+
+
+    // --- Assign Workload Iteratively ---
+    _worker_assignments.resize(_num_workers);
+
+    // ASSUMES dsts[0] is base of one large buffer
+    char * global_dst_buffer = static_cast<char*>(dsts[0]);
+
+    size_t current_global_dst_offset = 0; // Tracks position in the conceptual global buffer
+    size_t current_file_index = 0;
+    size_t current_offset_within_file = file_offsets[0]; // Start at the beginning of the first file's range
+
+    for (unsigned worker_idx = 0; worker_idx < _num_workers; ++worker_idx)
+    {
+        // Assign slightly more work to the first 'remainder_bytes' workers
+        size_t target_bytes_for_this_worker = base_bytes_per_worker + (worker_idx < remainder_bytes ? 1 : 0);
+        size_t bytes_assigned_to_this_worker = 0;
+
+        LOG(DEBUG) << "Assigning work to worker " << worker_idx << ", target bytes: " << target_bytes_for_this_worker;
+
+        while (bytes_assigned_to_this_worker < target_bytes_for_this_worker && current_file_index < num_files)
+        {
+            const std::string& file_path = paths[current_file_index];
+            const size_t file_start_offset = file_offsets[current_file_index];
+            const size_t file_total_requested_size = bytesizes[current_file_index];
+            char* current_global_dst_ptr = global_dst_buffer + current_global_dst_offset;
+
+            // Sanity check: current offset should be within the requested range for the file
+            if (current_offset_within_file < file_start_offset || current_offset_within_file >= file_start_offset + file_total_requested_size) {
+                // This case should ideally not happen if logic is correct, but indicates a problem if it does.
+                // It might happen if a file has bytesize 0.
+                    if (file_total_requested_size == 0) {
+                        // Skip zero-sized file request
+                        current_file_index++;
+                        if (current_file_index < num_files) {
+                            current_offset_within_file = file_offsets[current_file_index];
+                        }
+                        continue; // Move to next file
+                    } else {
+                    LOG(ERROR) << "Logic error: current_offset_within_file (" << current_offset_within_file
+                                << ") is outside the requested range [" << file_start_offset << ", "
+                                << file_start_offset + file_total_requested_size << ") for file " << current_file_index;
+                    throw std::logic_error("Internal error during workload assignment: Invalid file offset.");
+                    }
+            }
+
+            const size_t bytes_remaining_in_current_file = (file_start_offset + file_total_requested_size) - current_offset_within_file;
+            const size_t bytes_still_needed_by_worker = target_bytes_for_this_worker - bytes_assigned_to_this_worker;
+
+            const size_t bytes_to_assign_now = std::min(bytes_remaining_in_current_file, bytes_still_needed_by_worker);
+
+            if (bytes_to_assign_now > 0)
+            {
+                 // Create Task
+
+                 LOG(DEBUG) << "Assigned read file task to worker " << worker_idx << " file index: " << current_file_index << " file offset: " << current_offset_within_file << " bytesize: " << bytes_to_assign_now;
+                _worker_assignments[worker_idx].tasks.emplace_back(
+                    worker_idx,
+                    current_file_index,
+                    file_path,
+                    current_offset_within_file,
+                    bytes_to_assign_now,
+                    current_global_dst_ptr);
+
+                // --- Update State ---
+                bytes_assigned_to_this_worker += bytes_to_assign_now;
+                _worker_assignments[worker_idx].total_bytes += bytes_to_assign_now;
+                current_offset_within_file += bytes_to_assign_now;
+                current_global_dst_offset += bytes_to_assign_now; // Advance global destination offset
+
+                LOG(SPAM) << "  Worker " << worker_idx << ": Assigned task - File " << current_file_index
+                            << " ('" << file_path << "'), Offset " << current_offset_within_file - bytes_to_assign_now
+                            << ", Size " << bytes_to_assign_now;
+            }
+
+            // Check if we finished the current file
+            if (current_offset_within_file == file_start_offset + file_total_requested_size)
+            {
+                current_file_index++;
+                if (current_file_index < num_files)
+                {
+                    // Reset offset for the new file to its starting requested offset
+                    current_offset_within_file = file_offsets[current_file_index];
+                }
+            }
+        } // End while loop for assigning work to current worker
+
+        LOG(DEBUG) << "Finished assignment for worker " << worker_idx << ", total bytes assigned: " << bytes_assigned_to_this_worker;
+    } // End for loop iterating through workers
+
+    // Verification
+    size_t assigned_total = 0;
+    for (const auto & assignment : _worker_assignments)
+    {
+        assigned_total += assignment.total_bytes;
+    }
+
+    ASSERT(assigned_total == total_bytes_to_read) << "Verification failed: Total bytes assigned (" << assigned_total
+        << ") does not match total bytes requested (" << total_bytes_to_read << ")";
+
+    LOG(DEBUG) << "Workload assignment verification successful. Total bytes assigned: " << assigned_total;
+
+    unsigned i = 0;
+    for (auto & worker : _worker_assignments)
+    {
+        for (auto & read_task : worker.tasks)
+        {
+            const auto file_index = read_task.original_file_index;
+            _assignments[file_index].push_back(std::move(read_task));
+        }
+        ++i;
+    }
+
+    // Verification
+    for (unsigned i = 0; i < paths.size(); ++i)
+    {
+        size_t file_assigned_total = 0;
+        for (auto & task : _assignments[i])
+        {
+            file_assigned_total += task.size;
+        }
+        ASSERT(file_assigned_total == bytesizes[i]) << "File index " << i << " total assigned " << file_assigned_total << " not equal to file size " << bytesizes[i];
+    }
+}
+
+// Access the assignments of a given file by the original file index
+const std::vector<FileReadTask> & MultiFileWorkloadAssigner::file_assignments(unsigned file_index)
+{
+    return _assignments[file_index];
+}
+
+unsigned MultiFileWorkloadAssigner::get_num_workers() const
+{
+    return _num_workers;
+}
+
+} // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/assigner/assigner.cc
+++ b/cpp/streamer/impl/assigner/assigner.cc
@@ -64,7 +64,7 @@ _num_workers(_config->concurrency)
     size_t base_bytes_per_worker = bytes_per_worker(total_bytes_to_read, paths[0]);
     size_t base_bytes_remainder = total_bytes_to_read % _num_workers;
     LOG(DEBUG) << "base_bytes_per_worker: " << base_bytes_per_worker << " base_bytes_remainder: " << base_bytes_remainder;
-    
+
     _worker_assignments.resize(_num_workers);
 
     // ASSUMES dsts[0] is base of one large buffer

--- a/cpp/streamer/impl/assigner/assigner.h
+++ b/cpp/streamer/impl/assigner/assigner.h
@@ -37,12 +37,11 @@ struct Assigner
         std::shared_ptr<const Config> config);
 
     // Access the assignments for each worker
-    const std::vector<FileReadTask> & file_assignments(unsigned file_index);
+    const std::vector<FileReadTask> & file_assignments(unsigned file_index) const;
 
     unsigned get_num_workers() const;
 
  private:
-
     size_t bytes_per_worker(size_t total_bytes_to_read, const std::string & path);
 
  private:

--- a/cpp/streamer/impl/assigner/assigner.h
+++ b/cpp/streamer/impl/assigner/assigner.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <map>
+
+#include "streamer/impl/assigner/file_read_task/file_read_task.h"
+#include "streamer/impl/config/config.h"
+#include "streamer/impl/batches/batches.h"
+
+// Split reading from several files into several read assignments
+// Each read assignment is destined to a worker, represented as FileReadTask
+// FileReadTask will be later transformed to a Batch object
+
+namespace runai::llm::streamer::impl
+{
+
+// Generates the flat list of logical Request objects
+// including their destination base pointers.
+
+// struct FileRequests
+// {
+//     FileRequests(
+//         unsigned file_index,
+//         const std::string & path,
+//         size_t file_offset,
+//         size_t bytesizes,
+//         const std::vector<size_t> & internal_sizes,
+//         void * dst, // single continous buffer to write to
+//         const common::s3::Credentials& credentials);
+
+//     unsigned file_index;
+//     std::vector<std::shared_ptr<Request>> requests;
+//     size_t total_bytes = 0;
+// };
+
+
+// Holds all tasks assigned to a single worker
+
+struct WorkerTasks
+{
+    std::vector<FileReadTask> tasks;
+    size_t total_bytes = 0; // Total bytes assigned to this worker
+};
+
+// Distributes multi-file read workload across workers
+
+struct MultiFileWorkloadAssigner
+{
+    MultiFileWorkloadAssigner(
+        // Input file descriptions
+        const std::vector<std::string>& paths,
+        const std::vector<size_t>& file_offsets,
+        const std::vector<size_t>& bytesizes,
+        const std::vector<void*>& dsts,
+        std::shared_ptr<const Config> config);
+
+    // Access the assignments for each worker
+    const std::vector<FileReadTask> & file_assignments(unsigned file_index);
+
+    unsigned get_num_workers() const;
+
+ private:
+    std::shared_ptr<const Config> _config;
+    unsigned _num_workers;
+    std::map<unsigned, std::vector<FileReadTask>> _assignments; // assigned work for each file (key is the file index)
+    std::vector<WorkerTasks> _worker_assignments; // ordered by worker index
+};
+
+} // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/assigner/assigner.h
+++ b/cpp/streamer/impl/assigner/assigner.h
@@ -16,26 +16,6 @@
 namespace runai::llm::streamer::impl
 {
 
-// Generates the flat list of logical Request objects
-// including their destination base pointers.
-
-// struct FileRequests
-// {
-//     FileRequests(
-//         unsigned file_index,
-//         const std::string & path,
-//         size_t file_offset,
-//         size_t bytesizes,
-//         const std::vector<size_t> & internal_sizes,
-//         void * dst, // single continous buffer to write to
-//         const common::s3::Credentials& credentials);
-
-//     unsigned file_index;
-//     std::vector<std::shared_ptr<Request>> requests;
-//     size_t total_bytes = 0;
-// };
-
-
 // Holds all tasks assigned to a single worker
 
 struct WorkerTasks
@@ -46,9 +26,9 @@ struct WorkerTasks
 
 // Distributes multi-file read workload across workers
 
-struct MultiFileWorkloadAssigner
+struct Assigner
 {
-    MultiFileWorkloadAssigner(
+    Assigner(
         // Input file descriptions
         const std::vector<std::string>& paths,
         const std::vector<size_t>& file_offsets,
@@ -60,6 +40,10 @@ struct MultiFileWorkloadAssigner
     const std::vector<FileReadTask> & file_assignments(unsigned file_index);
 
     unsigned get_num_workers() const;
+
+ private:
+
+    size_t bytes_per_worker(size_t total_bytes_to_read, const std::string & path);
 
  private:
     std::shared_ptr<const Config> _config;

--- a/cpp/streamer/impl/assigner/assigner_test.cc
+++ b/cpp/streamer/impl/assigner/assigner_test.cc
@@ -1,0 +1,153 @@
+#include <gtest/gtest.h>
+#include <limits>
+#include <memory>
+#include <vector>
+#include <string>
+#include <set>
+#include "streamer/impl/assigner/assigner.h"
+#include "streamer/impl/config/config.h"
+#include "common/exception/exception.h"
+#include "common/response_code/response_code.h"
+#include "utils/random/random.h"
+#include "utils/logging/logging.h"
+
+namespace runai::llm::streamer::impl {
+
+struct AssignerTest : public ::testing::Test
+{
+ protected:
+    void SetUp() override
+    {
+        config = std::make_shared<Config>();
+        config->concurrency = utils::random::number(1, 20);
+    }
+
+    std::shared_ptr<Config> config;
+};
+
+TEST_F(AssignerTest, Empty_Inputs)
+{
+    std::vector<std::string> paths;
+    std::vector<size_t> offsets;
+    std::vector<size_t> sizes;
+    std::vector<void*> dsts;
+
+    // Empty input should not throw, just create empty assignments
+    EXPECT_NO_THROW(Assigner(paths, offsets, sizes, dsts, config));
+
+    Assigner assigner(paths, offsets, sizes, dsts, config);
+    EXPECT_THROW(assigner.file_assignments(0), std::exception);
+}
+
+TEST_F(AssignerTest, Mismatched_Input_Sizes)
+{
+    std::vector<std::string> paths = {utils::random::string()};
+    std::vector<size_t> offsets = {0};
+    std::vector<size_t> sizes = {utils::random::number(100, 1000)};
+    std::vector<void*> dsts;  // Empty dsts
+
+    EXPECT_THROW(Assigner(paths, offsets, sizes, dsts, config), runai::llm::streamer::common::Exception);
+}
+
+TEST_F(AssignerTest, Valid_Inputs)
+{
+    const size_t num_files = utils::random::number(1, 10);
+    std::vector<std::string> paths;
+    std::vector<size_t> offsets;
+    std::vector<size_t> sizes;
+    std::vector<void*> dsts;
+
+    for (size_t i = 0; i < num_files; ++i)
+    {
+        const size_t file_size = utils::random::number<size_t>(100000, 100000000);
+        paths.push_back(utils::random::string());
+        offsets.push_back(utils::random::number<size_t>(0, 100));
+        sizes.push_back(file_size);
+        dsts.push_back(reinterpret_cast<void *>(utils::random::number()));
+    }
+
+    EXPECT_NO_THROW(Assigner(paths, offsets, sizes, dsts, config));
+    const Assigner assigner(paths, offsets, sizes, dsts, config);
+
+    for (size_t i = 0; i < num_files; ++i)
+    {
+        const auto & tasks = assigner.file_assignments(i);
+        EXPECT_EQ(tasks[0].offset_in_file, offsets[i]);
+        size_t total = 0;
+        std::set<unsigned> worker_indices;
+        for (const auto & task : tasks)
+        {
+            EXPECT_EQ(worker_indices.count(task.worker_index), 0);
+            worker_indices.insert(task.worker_index);
+            total += task.size;
+        }
+        EXPECT_EQ(total, sizes[i]);
+    }
+}
+
+TEST_F(AssignerTest, Overflow_Check)
+{
+    std::vector<std::string> paths = {"file1", "file2"};
+    std::vector<size_t> offsets = {0, 0};
+    std::vector<size_t> sizes = {std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max()};
+    std::vector<void*> dsts = {nullptr, nullptr};
+
+    EXPECT_THROW(Assigner(paths, offsets, sizes, dsts, config), runai::llm::streamer::common::Exception);
+}
+
+TEST_F(AssignerTest, Zero_Size_Files)
+{
+    const size_t num_files = utils::random::number(1, 50);
+    std::vector<std::string> paths;
+    std::vector<size_t> offsets;
+    std::vector<size_t> sizes;
+    std::vector<void *> dsts;
+    for (size_t i = 0; i < num_files; ++i)
+    {
+        paths.push_back(utils::random::string());
+        offsets.push_back(utils::random::number<size_t>(0, 100));
+        if (utils::random::boolean())
+        {
+            sizes.push_back(0);
+        }
+        else
+        {
+            sizes.push_back(utils::random::number<size_t>(1, 1000));
+        }
+        dsts.push_back(nullptr);
+    }
+    dsts[0] = reinterpret_cast<void *>(utils::random::number());
+
+    const Assigner assigner(paths, offsets, sizes, dsts, config);
+
+    char * global_dst = static_cast<char *>(dsts[0]);
+    for (size_t i = 0; i < num_files; ++i)
+    {
+        const auto & tasks = assigner.file_assignments(i);
+        LOG(SPAM) << "file " << i << " tasks size: " << tasks.size();
+        if (sizes[i] == 0)
+        {
+            EXPECT_EQ(tasks.size(), 1);
+            EXPECT_EQ(tasks[0].size, 0);
+            EXPECT_EQ(tasks[0].offset_in_file, offsets[i]);
+            EXPECT_EQ(tasks[0].destination, global_dst);
+            continue;
+        }
+
+        EXPECT_EQ(tasks[0].offset_in_file, offsets[i]);
+        EXPECT_EQ(tasks[0].destination, global_dst);
+        global_dst += sizes[i];
+
+        size_t total = 0;
+        std::set<unsigned> worker_indices;
+        for (const auto & task : tasks)
+        {
+            EXPECT_EQ(worker_indices.count(task.worker_index), 0);
+            worker_indices.insert(task.worker_index);
+            total += task.size;
+        }
+        EXPECT_EQ(total, sizes[i]);
+    }
+}
+
+}  // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/assigner/file_read_task/BUILD
+++ b/cpp/streamer/impl/assigner/file_read_task/BUILD
@@ -1,0 +1,6 @@
+load("//:rules.bzl", "runai_cc_auto_library")
+
+runai_cc_auto_library(
+    name = "file_read_task",
+)
+

--- a/cpp/streamer/impl/assigner/file_read_task/file_read_task.cc
+++ b/cpp/streamer/impl/assigner/file_read_task/file_read_task.cc
@@ -1,0 +1,16 @@
+#include "streamer/impl/assigner/file_read_task/file_read_task.h"
+
+namespace runai::llm::streamer::impl
+{
+
+// Constructor
+FileReadTask::FileReadTask(unsigned worker_index, unsigned file_idx, const std::string & p, size_t offset, size_t sz, char* dst) :
+    worker_index(worker_index),
+    original_file_index(file_idx),
+    path(p),
+    offset_in_file(offset),
+    size(sz),
+    destination(dst)
+{}
+
+} // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/assigner/file_read_task/file_read_task.cc
+++ b/cpp/streamer/impl/assigner/file_read_task/file_read_task.cc
@@ -4,7 +4,7 @@ namespace runai::llm::streamer::impl
 {
 
 // Constructor
-FileReadTask::FileReadTask(unsigned worker_index, unsigned file_idx, const std::string & p, size_t offset, size_t sz, char* dst) :
+FileReadTask::FileReadTask(unsigned worker_index, unsigned file_idx, const std::string & p, size_t offset, size_t sz, char * dst) :
     worker_index(worker_index),
     original_file_index(file_idx),
     path(p),

--- a/cpp/streamer/impl/assigner/file_read_task/file_read_task.h
+++ b/cpp/streamer/impl/assigner/file_read_task/file_read_task.h
@@ -14,7 +14,7 @@ struct FileReadTask
                  const std::string& p,
                  size_t offset,
                  size_t sz,
-                 char* dst);
+                 char * dst);
 
     FileReadTask(FileReadTask&&) = default;
     FileReadTask& operator=(FileReadTask&&) = default;
@@ -25,7 +25,7 @@ struct FileReadTask
     std::string path;             // Path of the file to read
     size_t offset_in_file;        // Starting byte offset within this file
     size_t size;                  // Number of bytes to read
-    char* destination;            // Pointer to the destination buffer for this task's data
+    char * destination;            // Pointer to the destination buffer for this task's data
 };
 
 } // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/assigner/file_read_task/file_read_task.h
+++ b/cpp/streamer/impl/assigner/file_read_task/file_read_task.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <string>
+
+namespace runai::llm::streamer::impl
+{
+
+// Represents a single contiguous read operation from a specific file
+
+struct FileReadTask
+{
+    FileReadTask(unsigned worker_index,
+                 unsigned file_idx,
+                 const std::string& p,
+                 size_t offset,
+                 size_t sz,
+                 char* dst);
+
+    FileReadTask(FileReadTask&&) = default;
+    FileReadTask& operator=(FileReadTask&&) = default;
+
+    unsigned worker_index;
+
+    unsigned original_file_index; // Index from the input vectors
+    std::string path;             // Path of the file to read
+    size_t offset_in_file;        // Starting byte offset within this file
+    size_t size;                  // Number of bytes to read
+    char* destination;            // Pointer to the destination buffer for this task's data
+};
+
+} // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/batch/batch.h
+++ b/cpp/streamer/impl/batch/batch.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <ostream>
 
 #include "common/storage_uri/storage_uri.h"
 #include "common/s3_wrapper/s3_wrapper.h"
@@ -47,7 +48,7 @@ struct Batch
     Batch(Batch &&) = default;
     Batch & operator=(Batch &&) = default;
 
-    Batch(unsigned file_index, const std::string & path, const common::s3::S3ClientWrapper::Params & params, Range && range, char * dst, const Tasks && tasks, std::shared_ptr<common::Responder> responder, std::shared_ptr<const Config> config);
+    Batch(unsigned worker_index, unsigned file_index, const std::string & path, const common::s3::S3ClientWrapper::Params & params, Range && range, char * dst, const Tasks && tasks, std::shared_ptr<common::Responder> responder, std::shared_ptr<const Config> config);
 
     void execute(std::atomic<bool> & stopped);
 
@@ -55,8 +56,10 @@ struct Batch
     void finished_until(size_t file_offset, common::ResponseCode ret = common::ResponseCode::Success);
     unsigned finished_until() const;
 
-    unsigned file_index;
+    unsigned worker_index;
 
+    // source file
+    unsigned file_index;
     std::string path;
 
     // s3 parameters
@@ -84,5 +87,7 @@ struct Batch
 
     std::unique_ptr<Reader> _reader;
 };
+
+std::ostream & operator<<(std::ostream & os, const Batch & r);
 
 }; // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/batch/batch.h
+++ b/cpp/streamer/impl/batch/batch.h
@@ -47,13 +47,15 @@ struct Batch
     Batch(Batch &&) = default;
     Batch & operator=(Batch &&) = default;
 
-    Batch(const std::string & path, const common::s3::S3ClientWrapper::Params & params, Range && range, char * dst, const Tasks && tasks, std::shared_ptr<common::Responder> responder, std::shared_ptr<const Config> config);
+    Batch(unsigned file_index, const std::string & path, const common::s3::S3ClientWrapper::Params & params, Range && range, char * dst, const Tasks && tasks, std::shared_ptr<common::Responder> responder, std::shared_ptr<const Config> config);
 
     void execute(std::atomic<bool> & stopped);
 
     // notify tasks until file offset
     void finished_until(size_t file_offset, common::ResponseCode ret = common::ResponseCode::Success);
     unsigned finished_until() const;
+
+    unsigned file_index;
 
     std::string path;
 

--- a/cpp/streamer/impl/batch/batch.h
+++ b/cpp/streamer/impl/batch/batch.h
@@ -48,7 +48,7 @@ struct Batch
     Batch(Batch &&) = default;
     Batch & operator=(Batch &&) = default;
 
-    Batch(unsigned worker_index, unsigned file_index, const std::string & path, const common::s3::S3ClientWrapper::Params & params, Range && range, char * dst, const Tasks && tasks, std::shared_ptr<common::Responder> responder, std::shared_ptr<const Config> config);
+    Batch(unsigned worker_index, unsigned file_index, const std::string & path, const common::s3::S3ClientWrapper::Params & params, Range && range, const Tasks && tasks, std::shared_ptr<common::Responder> responder, std::shared_ptr<const Config> config);
 
     void execute(std::atomic<bool> & stopped);
 
@@ -67,9 +67,6 @@ struct Batch
 
     // range in file
     Range range;
-
-    // start offset in destination buffer
-    char * dst;
 
     Tasks tasks;
 

--- a/cpp/streamer/impl/batch/batch_test.cc
+++ b/cpp/streamer/impl/batch/batch_test.cc
@@ -59,7 +59,7 @@ TEST(Batch, Finished_Until)
     // create batch
     const auto config = std::make_shared<Config>();
 
-    Batch batch(path, params, std::move(range), nullptr, std::move(tasks), responder, config);
+    Batch batch(utils::random::number(), path, params, std::move(range), nullptr, std::move(tasks), responder, config);
 
     // execute part of the tasks
 
@@ -131,7 +131,7 @@ TEST(Read, Sanity)
         tasks.push_back(std::move(task));
     }
 
-    Batch batch(path, params, std::move(range), dst_ptr, std::move(tasks), responder, config);
+    Batch batch(utils::random::number(), path, params, std::move(range), dst_ptr, std::move(tasks), responder, config);
 
     std::atomic<bool> stopped(false);
     EXPECT_NO_THROW(batch.execute(stopped));
@@ -191,7 +191,7 @@ TEST(Read, Error)
         tasks.push_back(std::move(task));
     }
 
-     Batch batch(path, params, std::move(range), dst_ptr, std::move(tasks), responder, config);
+     Batch batch(utils::random::number(), path, params, std::move(range), dst_ptr, std::move(tasks), responder, config);
 
     std::atomic<bool> stopped(false);
     EXPECT_NO_THROW(batch.execute(stopped));
@@ -242,7 +242,7 @@ TEST(Read, Already_Stopped)
         tasks.push_back(std::move(task));
     }
 
-    Batch batch(path, params, std::move(range), dst_ptr, std::move(tasks), responder, config);
+    Batch batch(utils::random::number(), path, params, std::move(range), dst_ptr, std::move(tasks), responder, config);
 
     std::atomic<bool> stopped(true);
     EXPECT_NO_THROW(batch.execute(stopped));
@@ -307,7 +307,7 @@ TEST(Read, Stopped_During_Read)
         offset += chunks[i];
     }
 
-    Batch batch(path, params, std::move(range), dst_ptr, std::move(tasks), responder, config);
+    Batch batch(utils::random::number(), path, params, std::move(range), dst_ptr, std::move(tasks), responder, config);
 
     std::atomic<bool> stopped(false);
 
@@ -435,7 +435,7 @@ TEST(Read, Stopped_During_Async_Read)
         offset += chunks[i];
     }
 
-    Batch batch(path, params, std::move(range), dst_ptr, std::move(tasks), responder, config);
+    Batch batch(utils::random::number(), path, params, std::move(range), dst_ptr, std::move(tasks), responder, config);
 
     std::atomic<bool> stopped(false);
 

--- a/cpp/streamer/impl/batches/BUILD
+++ b/cpp/streamer/impl/batches/BUILD
@@ -9,6 +9,7 @@ runai_cc_auto_library(
         "//common/exception",
         "//common/responder",
         "//streamer/impl/file",
+        "//streamer/impl/assigner/file_read_task",
         "//streamer/impl/s3",
         "//utils/logging",
     ],
@@ -22,5 +23,6 @@ runai_cc_test(
         ":batches",
         "//utils/random",
         "//utils/temp/file",
+        "//streamer/impl/assigner",
     ],
 )

--- a/cpp/streamer/impl/batches/batches.cc
+++ b/cpp/streamer/impl/batches/batches.cc
@@ -134,7 +134,7 @@ void Batches::build_tasks(std::shared_ptr<const Config> config, const std::strin
         const size_t request_size = internal_sizes[request_index];
 
         handle_request(v_tasks, request_index, request_file_offset, request_size, current_request_destination);
-        LOG(INFO) << "created request index " << request_index << " dst " << static_cast<char *>(current_request_destination);
+        LOG(DEBUG) << "created request index " << request_index << " dst " << static_cast<void *>(current_request_destination);
 
         current_request_destination += request_size;
         request_file_offset += request_size;

--- a/cpp/streamer/impl/batches/batches.cc
+++ b/cpp/streamer/impl/batches/batches.cc
@@ -21,46 +21,82 @@
 namespace runai::llm::streamer::impl
 {
 
-Batches::BatchItr::BatchItr(unsigned num_batches, size_t worker_bytesize) :
-    _num_batches(num_batches),
-    _worker_bytesize(worker_bytesize),
-    _current_worker_bytesize(_worker_bytesize)
-{}
+Batches::BatchItr::BatchItr(const std::vector<FileReadTask> & file_read_tasks) :
+     _file_read_tasks(file_read_tasks),
+    _num_batches(file_read_tasks.size()),
+    _current_task_index(0)
+{
+    ASSERT(_num_batches) << "Zero file read requests";
+    _current_worker_index = file_read_tasks[_current_task_index].worker_index;
+    _current_worker_bytesize = file_read_tasks[_current_task_index].size;
+}
 
 unsigned Batches::BatchItr::current_index() const
+{
+    return _current_task_index;
+}
+
+unsigned Batches::BatchItr::current_worker_index() const
 {
     return _current_worker_index;
 }
 
-size_t Batches::BatchItr::worker_bytesize() const
+const FileReadTask & Batches::BatchItr::read_task(unsigned index) const
 {
-    return _worker_bytesize;
+    ASSERT(index < _num_batches) << "Index overflow " << index << " should be less than " << _num_batches;
+    return _file_read_tasks[index];
+}
+
+unsigned Batches::BatchItr::workers() const
+{
+    return _num_batches;
+}
+
+unsigned Batches::BatchItr::worker_index(unsigned index) const
+{
+    return read_task(index).worker_index;
+}
+
+const FileReadTask & Batches::BatchItr::current_read_task() const
+{
+    ASSERT(_current_task_index < _num_batches) << "Batches iterator overflow _current_task_index = " << _current_task_index << " num_batches = " << _num_batches;
+    return _file_read_tasks[_current_task_index];
 }
 
 size_t Batches::BatchItr::consume(size_t bytesize)
 {
-    if (_current_worker_bytesize == 0)
+    if (bytesize == 0)
+    {
+        LOG(DEBUG) << "consuming zero bytes request";
+    }
+    if (_current_worker_bytesize == 0 && bytesize)
     {
         // advance to the next worker
-        ++_current_worker_index;
-        _current_worker_bytesize = _worker_bytesize;
+        ++_current_task_index;
+        _current_worker_index = worker_index(_current_task_index);
+        _current_worker_bytesize = read_task(_current_task_index).size;
     }
-
-    ASSERT(_current_worker_index < _num_batches) << "Batches iterator overflow";
 
     auto to_read = std::min<size_t>(_current_worker_bytesize, bytesize);
     _current_worker_bytesize -= to_read;
     return to_read;
 }
 
-Batches::Batches(unsigned file_index, std::shared_ptr<const Config> config, std::shared_ptr<common::Responder> responder, const std::string & path, const common::s3::S3ClientWrapper::Params & params, size_t file_offset, size_t bytesize, void * dst, unsigned num_sizes, size_t * internal_sizes) :
+Batches::Batches(unsigned file_index,
+                    const std::vector<FileReadTask> & file_read_tasks,
+                    std::shared_ptr<const Config> config,
+                    std::shared_ptr<common::Responder> responder,
+                    const std::string & path,
+                    const common::s3::S3ClientWrapper::Params & params,
+                    size_t file_offset,
+                    size_t bytesize,
+                    const std::vector<size_t> & internal_sizes) :
     _file_index(file_index),
-    _itr(config->concurrency, batch_bytesize(bytesize, *config, params.uri)),
+    _itr(file_read_tasks),
     _responder(responder)
 {
-    LOG(DEBUG) << "worker maximal range size is " << utils::logging::human_readable_size(_itr.worker_bytesize());
-    _batches.reserve(config->concurrency);
-    build_tasks(config, path, params, file_offset, dst, num_sizes, internal_sizes);
+    _batches.reserve(file_read_tasks.size());
+    build_tasks(config, path, params, file_offset, internal_sizes);
 }
 
 unsigned Batches::size() const
@@ -68,20 +104,20 @@ unsigned Batches::size() const
     return _batches.size();
 }
 
-size_t Batches::batch_bytesize(size_t bytesize, const Config & config, std::shared_ptr<common::s3::StorageUri> uri)
-{
-    size_t result = std::ceil(static_cast<double>(bytesize) / static_cast<double>(config.concurrency));
+// size_t Batches::batch_bytesize(size_t bytesize, const Config & config, std::shared_ptr<common::s3::StorageUri> uri)
+// {
+//     size_t result = std::ceil(static_cast<double>(bytesize) / static_cast<double>(config.concurrency));
 
-    // round up to the configured chunk byte size
-    const auto chunk_bytesize = (uri.get() == nullptr ? config.fs_block_bytesize : config.s3_block_bytesize);
-    int remainder = result % chunk_bytesize;
-    if (remainder)
-    {
-        result += (chunk_bytesize - remainder);
-    }
+//     // round up to the configured chunk byte size
+//     const auto chunk_bytesize = (uri.get() == nullptr ? config.fs_block_bytesize : config.s3_block_bytesize);
+//     int remainder = result % chunk_bytesize;
+//     if (remainder)
+//     {
+//         result += (chunk_bytesize - remainder);
+//     }
 
-    return result;
-}
+//     return result;
+// }
 
 Batch & Batches::operator[](unsigned index)
 {
@@ -94,35 +130,43 @@ size_t Batches::total() const
     return _total;
 }
 
-void Batches::build_tasks(std::shared_ptr<const Config> config, const std::string & path, const common::s3::S3ClientWrapper::Params & params, size_t file_offset, void * dst, unsigned num_sizes, size_t * internal_sizes)
+void Batches::build_tasks(std::shared_ptr<const Config> config, const std::string & path, const common::s3::S3ClientWrapper::Params & params, size_t file_offset, const std::vector<size_t> & internal_sizes)
 {
-    std::vector<Tasks> v_tasks(config->concurrency);
-    std::vector<Range> v_ranges(config->concurrency);
+    const auto num_workers = _itr.workers();
+    LOG(DEBUG) << "Building tasks for " <<num_workers << " workers";
+    std::vector<Tasks> v_tasks(num_workers);
+    std::vector<Range> v_ranges(num_workers);
 
-    size_t * size_ptr = internal_sizes;
+    auto num_sizes = internal_sizes.size();
     size_t request_file_offset = file_offset;
+
+    auto destination_start = static_cast<char *>(_itr.read_task(0).destination);
+
+    auto current_request_destination = destination_start;
 
     // iterate over the workers and the requests to fill each worker share
     for (unsigned request_index = 0; request_index < num_sizes; ++request_index)
     {
         // create tasks for the entire requested range before sending to the threadpool
-        const size_t request_size = *size_ptr;
+        const size_t request_size = internal_sizes[request_index];
 
-        handle_request(v_tasks, request_index, request_file_offset, request_size);
+        handle_request(v_tasks, request_index, request_file_offset, request_size, current_request_destination);
 
+        current_request_destination += request_size;
         request_file_offset += request_size;
-        ++size_ptr;
     }
 
-    auto dst_ = static_cast<char *>(dst);
+    auto dst_ = destination_start;
 
-    for (unsigned i = 0; i < config->concurrency; ++i)
+    for (unsigned i = 0; i < num_workers; ++i)
     {
+        const auto worker_index = _itr.worker_index(i);
         auto & tasks = v_tasks[i];
         auto size = tasks.size();
         if (size == 0)
         {
-            break;
+            LOG(WARNING) << "Zero tasks for worker index " << _itr.worker_index(i);
+            continue;
         }
 
         auto range = Range(tasks);
@@ -130,17 +174,19 @@ void Batches::build_tasks(std::shared_ptr<const Config> config, const std::strin
 
         const auto range_size = range.size;
 
-        _batches.emplace_back(_file_index, path, params, std::move(range), dst_, std::move(tasks), _responder, config);
+        _batches.emplace_back(worker_index, _file_index, path, params, std::move(range), dst_, std::move(tasks), _responder, config);
 
         dst_ += range_size;
     }
 }
 
-void Batches::handle_request(std::vector<Tasks> & v_tasks, unsigned request_index, size_t request_file_offset, size_t request_size)
+void Batches::handle_request(std::vector<Tasks> & v_tasks, unsigned request_index, size_t request_file_offset, size_t request_size, char * destination)
 {
     LOG(DEBUG) << "request file offset " << request_file_offset << " size " << request_size;
 
     // create tasks info
+
+    // map worker index to tasks info
     std::map<unsigned, Task::Info> infos;
 
     auto bytes_to_request = request_size;
@@ -150,18 +196,20 @@ void Batches::handle_request(std::vector<Tasks> & v_tasks, unsigned request_inde
     {
         auto to_read = _itr.consume(bytes_to_request);
         Task::Info info(task_offset, to_read);
-        infos.try_emplace(_itr.current_index(), std::move(info));
+        auto worker_index = _itr.current_index();
+        infos.try_emplace(worker_index, std::move(info));
         task_offset += to_read;
         bytes_to_request -= to_read;
     } while (bytes_to_request > 0);
 
-    auto request_ptr = std::make_shared<Request>(request_file_offset, request_index, infos.size(), request_size);
+    auto request_ptr = std::make_shared<Request>(request_file_offset, request_index, infos.size(), request_size, destination);
 
     // create tasks
     for (auto & [batch_id, info] : infos)
     {
         Task task(request_ptr, std::move(info));
         LOG(SPAM) << task;
+        ASSERT(batch_id < v_tasks.size()) << batch_id << " v_tasks.size() " << v_tasks.size();
         v_tasks[batch_id].emplace_back(std::move(task));
     }
 }

--- a/cpp/streamer/impl/batches/batches.cc
+++ b/cpp/streamer/impl/batches/batches.cc
@@ -83,20 +83,18 @@ size_t Batches::BatchItr::consume(size_t bytesize)
 }
 
 Batches::Batches(unsigned file_index,
-                    const std::vector<FileReadTask> & file_read_tasks,
-                    std::shared_ptr<const Config> config,
-                    std::shared_ptr<common::Responder> responder,
-                    const std::string & path,
-                    const common::s3::S3ClientWrapper::Params & params,
-                    size_t file_offset,
-                    size_t bytesize,
-                    const std::vector<size_t> & internal_sizes) :
+                 const std::vector<FileReadTask> & file_read_tasks,
+                 std::shared_ptr<const Config> config,
+                 std::shared_ptr<common::Responder> responder,
+                 const std::string & path,
+                 const common::s3::S3ClientWrapper::Params & params,
+                 const std::vector<size_t> & internal_sizes) :
     _file_index(file_index),
     _itr(file_read_tasks),
     _responder(responder)
 {
     _batches.reserve(file_read_tasks.size());
-    build_tasks(config, path, params, file_offset, internal_sizes);
+    build_tasks(config, path, params, internal_sizes);
 }
 
 unsigned Batches::size() const
@@ -115,7 +113,7 @@ size_t Batches::total() const
     return _total;
 }
 
-void Batches::build_tasks(std::shared_ptr<const Config> config, const std::string & path, const common::s3::S3ClientWrapper::Params & params, size_t file_offset, const std::vector<size_t> & internal_sizes)
+void Batches::build_tasks(std::shared_ptr<const Config> config, const std::string & path, const common::s3::S3ClientWrapper::Params & params, const std::vector<size_t> & internal_sizes)
 {
     const auto num_workers = _itr.workers();
     LOG(DEBUG) << "Building tasks for " <<num_workers << " workers";
@@ -123,7 +121,7 @@ void Batches::build_tasks(std::shared_ptr<const Config> config, const std::strin
     std::vector<Range> v_ranges(num_workers);
 
     auto num_sizes = internal_sizes.size();
-    size_t request_file_offset = file_offset;
+    size_t request_file_offset = _itr.read_task(0).offset_in_file;
 
     auto destination_start = static_cast<char *>(_itr.read_task(0).destination);
 

--- a/cpp/streamer/impl/batches/batches.cc
+++ b/cpp/streamer/impl/batches/batches.cc
@@ -53,7 +53,8 @@ size_t Batches::BatchItr::consume(size_t bytesize)
     return to_read;
 }
 
-Batches::Batches(std::shared_ptr<const Config> config, std::shared_ptr<common::Responder> responder, const std::string & path, const common::s3::S3ClientWrapper::Params & params, size_t file_offset, size_t bytesize, void * dst, unsigned num_sizes, size_t * internal_sizes) :
+Batches::Batches(unsigned file_index, std::shared_ptr<const Config> config, std::shared_ptr<common::Responder> responder, const std::string & path, const common::s3::S3ClientWrapper::Params & params, size_t file_offset, size_t bytesize, void * dst, unsigned num_sizes, size_t * internal_sizes) :
+    _file_index(file_index),
     _itr(config->concurrency, batch_bytesize(bytesize, *config, params.uri)),
     _responder(responder)
 {
@@ -129,7 +130,7 @@ void Batches::build_tasks(std::shared_ptr<const Config> config, const std::strin
 
         const auto range_size = range.size;
 
-        _batches.emplace_back(path, params, std::move(range), dst_, std::move(tasks), _responder, config);
+        _batches.emplace_back(_file_index, path, params, std::move(range), dst_, std::move(tasks), _responder, config);
 
         dst_ += range_size;
     }

--- a/cpp/streamer/impl/batches/batches.h
+++ b/cpp/streamer/impl/batches/batches.h
@@ -26,8 +26,6 @@ struct Batches
            std::shared_ptr<common::Responder> responder,
            const std::string & path,
            const common::s3::S3ClientWrapper::Params & params,
-           size_t file_offset,
-           size_t bytesize,
            const std::vector<size_t> & internal_sizes);
 
     Batches(Batches &&) = default;
@@ -63,7 +61,7 @@ struct Batches
     };
 
     // create all the tasks
-    void build_tasks(std::shared_ptr<const Config> config, const std::string & path, const common::s3::S3ClientWrapper::Params & params, size_t file_offset, const std::vector<size_t> & internal_sizes);
+    void build_tasks(std::shared_ptr<const Config> config, const std::string & path, const common::s3::S3ClientWrapper::Params & params, const std::vector<size_t> & internal_sizes);
 
     // create tasks of a given request
     void handle_request(std::vector<Tasks> & v_tasks, unsigned request_index, size_t request_file_offset, size_t request_size, char * destination);

--- a/cpp/streamer/impl/batches/batches.h
+++ b/cpp/streamer/impl/batches/batches.h
@@ -10,15 +10,28 @@
 #include "streamer/impl/config/config.h"
 #include "streamer/impl/request/request.h"
 #include "streamer/impl/reader/reader.h"
+#include "streamer/impl/assigner/file_read_task/file_read_task.h"
 
 namespace runai::llm::streamer::impl
 {
 
-// Transforms a file read request into batches
+// Transforms a file read request into batches, one batch per process
+// Batches is a group of Batch objects, which together read the same file
 
 struct Batches
 {
-    Batches(unsigned file_index, std::shared_ptr<const Config> config, std::shared_ptr<common::Responder> responder, const std::string & path, const common::s3::S3ClientWrapper::Params & params, size_t file_offset, size_t bytesize, void * dst, unsigned num_sizes, size_t * internal_sizes);
+    Batches(unsigned file_index,
+           const std::vector<FileReadTask> & file_read_tasks,
+           std::shared_ptr<const Config> config,
+           std::shared_ptr<common::Responder> responder,
+           const std::string & path,
+           const common::s3::S3ClientWrapper::Params & params,
+           size_t file_offset,
+           size_t bytesize,
+           const std::vector<size_t> & internal_sizes);
+
+    Batches(Batches &&) = default;
+    Batches & operator=(Batches &&) = default;
 
     unsigned size() const;
 
@@ -29,27 +42,31 @@ struct Batches
  private:
     struct BatchItr
     {
-        BatchItr(unsigned num_batches, size_t worker_bytesize);
+        BatchItr(const std::vector<FileReadTask> & file_read_tasks);
 
-        size_t worker_bytesize() const;
         unsigned current_index() const;
+        unsigned current_worker_index() const;
         size_t consume(size_t bytesize);
 
+        const FileReadTask & current_read_task() const;
+        const FileReadTask & read_task(unsigned i) const;
+
+        unsigned workers() const;
+        unsigned worker_index(unsigned index) const;
+
      private:
+        const std::vector<FileReadTask> & _file_read_tasks;
         const unsigned _num_batches;
-        unsigned _current_worker_index = 0;
-        const size_t _worker_bytesize;
+        unsigned _current_task_index;
+        unsigned _current_worker_index;
         size_t _current_worker_bytesize;
     };
 
-    // calculate the range size of each batch
-    size_t batch_bytesize(const size_t bytesize, const Config & config, std::shared_ptr<common::s3::StorageUri> uri);
-
     // create all the tasks
-    void build_tasks(std::shared_ptr<const Config> config, const std::string & path, const common::s3::S3ClientWrapper::Params & params, size_t file_offset, void * dst, unsigned num_sizes, size_t * internal_sizes);
+    void build_tasks(std::shared_ptr<const Config> config, const std::string & path, const common::s3::S3ClientWrapper::Params & params, size_t file_offset, const std::vector<size_t> & internal_sizes);
 
     // create tasks of a given request
-    void handle_request(std::vector<Tasks> & v_tasks, unsigned request_index, size_t request_file_offset, size_t request_size);
+    void handle_request(std::vector<Tasks> & v_tasks, unsigned request_index, size_t request_file_offset, size_t request_size, char * destination);
 
     unsigned _file_index;
 

--- a/cpp/streamer/impl/batches/batches.h
+++ b/cpp/streamer/impl/batches/batches.h
@@ -18,7 +18,7 @@ namespace runai::llm::streamer::impl
 
 struct Batches
 {
-    Batches(std::shared_ptr<const Config> config, std::shared_ptr<common::Responder> responder, const std::string & path, const common::s3::S3ClientWrapper::Params & params, size_t file_offset, size_t bytesize, void * dst, unsigned num_sizes, size_t * internal_sizes);
+    Batches(unsigned file_index, std::shared_ptr<const Config> config, std::shared_ptr<common::Responder> responder, const std::string & path, const common::s3::S3ClientWrapper::Params & params, size_t file_offset, size_t bytesize, void * dst, unsigned num_sizes, size_t * internal_sizes);
 
     unsigned size() const;
 
@@ -50,6 +50,8 @@ struct Batches
 
     // create tasks of a given request
     void handle_request(std::vector<Tasks> & v_tasks, unsigned request_index, size_t request_file_offset, size_t request_size);
+
+    unsigned _file_index;
 
     unsigned _size;
 

--- a/cpp/streamer/impl/batches/batches_test.cc
+++ b/cpp/streamer/impl/batches/batches_test.cc
@@ -60,13 +60,10 @@ TEST(Batches, Sanity)
         dsts.push_back(buffers[i].data());
     }
     {
-        MultiFileWorkloadAssigner assigner(paths, file_offsets, bytesizes, dsts, config);
+        Assigner assigner(paths, file_offsets, bytesizes, dsts, config);
 
         EXPECT_GT(assigner.file_assignments(0).size(), 0);
-        if (num_files == 1)
-        {
-            EXPECT_EQ(assigner.file_assignments(0).size(), config->concurrency);
-        }
+        EXPECT_LE(assigner.file_assignments(0).size(), config->concurrency);
 
         // create internal division to divide the file into requests (each request represent a tensor)
 
@@ -164,10 +161,10 @@ TEST(Batches, Failed_Reader)
         bytesizes.push_back(size);
         dsts.push_back(dst.data());
 
-        MultiFileWorkloadAssigner assigner(paths, file_offsets, bytesizes, dsts, config);
+        Assigner assigner(paths, file_offsets, bytesizes, dsts, config);
 
         EXPECT_GT(assigner.file_assignments(0).size(), 0);
-        EXPECT_EQ(assigner.file_assignments(0).size(), config->concurrency);
+        EXPECT_LE(assigner.file_assignments(0).size(), config->concurrency);
 
         Batches batches(utils::random::number(), assigner.file_assignments(0), config, responder, file_path, s3_params, 0, size, chunks);
     }
@@ -235,10 +232,10 @@ TEST(Batches, Zero_Size_Request)
         bytesizes.push_back(size);
         dsts.push_back(dst.data());
 
-        MultiFileWorkloadAssigner assigner(paths, file_offsets, bytesizes, dsts, config);
+        Assigner assigner(paths, file_offsets, bytesizes, dsts, config);
 
         EXPECT_GT(assigner.file_assignments(0).size(), 0);
-        EXPECT_EQ(assigner.file_assignments(0).size(), config->concurrency);
+        EXPECT_LE(assigner.file_assignments(0).size(), config->concurrency);
 
         Batches batches(utils::random::number(), assigner.file_assignments(0), config, responder, file.path, s3_params, 0, size, chunks);
 

--- a/cpp/streamer/impl/batches/batches_test.cc
+++ b/cpp/streamer/impl/batches/batches_test.cc
@@ -74,7 +74,7 @@ TEST(Batches, Sanity)
             auto total_chunks_size = std::accumulate(chunks.begin(), chunks.end(), 0u);
             EXPECT_EQ(total_chunks_size, bytesizes[file_idx]);
 
-            Batches batches(utils::random::number(), assigner.file_assignments(file_idx), config, responder, file[file_idx].path, s3_params, 0, bytesizes[file_idx], chunks);
+            Batches batches(utils::random::number(), assigner.file_assignments(file_idx), config, responder, file[file_idx].path, s3_params, chunks);
 
             // execute tasks
             for (unsigned i = 0; i < batches.size(); ++i)
@@ -166,7 +166,7 @@ TEST(Batches, Failed_Reader)
         EXPECT_GT(assigner.file_assignments(0).size(), 0);
         EXPECT_LE(assigner.file_assignments(0).size(), config->concurrency);
 
-        Batches batches(utils::random::number(), assigner.file_assignments(0), config, responder, file_path, s3_params, 0, size, chunks);
+        Batches batches(utils::random::number(), assigner.file_assignments(0), config, responder, file_path, s3_params, chunks);
     }
     catch(const common::Exception & e)
     {
@@ -237,7 +237,7 @@ TEST(Batches, Zero_Size_Request)
         EXPECT_GT(assigner.file_assignments(0).size(), 0);
         EXPECT_LE(assigner.file_assignments(0).size(), config->concurrency);
 
-        Batches batches(utils::random::number(), assigner.file_assignments(0), config, responder, file.path, s3_params, 0, size, chunks);
+        Batches batches(utils::random::number(), assigner.file_assignments(0), config, responder, file.path, s3_params, chunks);
 
         // execute tasks
         for (unsigned i = 0; i < batches.size(); ++i)

--- a/cpp/streamer/impl/batches/batches_test.cc
+++ b/cpp/streamer/impl/batches/batches_test.cc
@@ -4,81 +4,129 @@
 #include <memory>
 #include <set>
 
+#include "streamer/impl/assigner/assigner.h"
+
 #include "utils/random/random.h"
 #include "utils/temp/file/file.h"
 
 #include "common/exception/exception.h"
+#include "utils/logging/logging.h"
 
 namespace runai::llm::streamer::impl
 {
 
 TEST(Batches, Sanity)
 {
-    auto size = utils::random::number(1000, 100000);
-    const unsigned num_chunks = utils::random::number(1, 20);
-    EXPECT_LT(num_chunks, size);
+    auto num_files = utils::random::number(1, 10);
+    LOG(DEBUG) << "number of files " << num_files;
 
-    const auto data = utils::random::buffer(size);
-    utils::temp::File file(data);
+    common::s3::S3ClientWrapper::Params s3_params;
 
-    // create internal division to divide the file into requests (each request represent a tensor)
-    auto chunks = utils::random::chunks(size, num_chunks);
+    std::vector<std::string> paths;
+    std::vector<size_t> file_offsets;
+    std::vector<size_t> bytesizes;
+    std::vector<void*> dsts;
+    std::vector<std::vector<unsigned>> covered(num_files);
+    std::vector<size_t> total_bytes(num_files);
+    std::vector<std::vector<uint8_t>> data(num_files);
+    std::vector<std::vector<char>> buffers(num_files);
+    std::vector<unsigned> num_chunks(num_files);
+    std::vector<utils::temp::File> file;
+    std::vector<std::set<int>> expected_responses(num_files);
 
     const auto chunk_size = utils::random::number<size_t>(1, 1024);
     auto config = std::make_shared<Config>(utils::random::number(1, 20), utils::random::number<size_t>(1, 1024), chunk_size, false /* do not force minimum chunk size */);
+    auto responder = std::make_shared<common::Responder>(0);
 
-    std::vector<char> dst(size);
-    auto responder = std::make_shared<common::Responder>(num_chunks);
-
-    size_t total_bytes = 0;
-    std::vector<unsigned> covered(size);
-
+    for (unsigned i = 0; i < num_files; ++i)
     {
-        common::s3::S3ClientWrapper::Params s3_params;
-        Batches batches(utils::random::number(), config, responder, file.path, s3_params, 0, size, dst.data(), num_chunks, chunks.data());
+        auto size = utils::random::number(1000, 100000);
+        num_chunks[i] = utils::random::number(1, 20);
+        EXPECT_LT(num_chunks[i], size);
+        responder->increment(num_chunks[i]);
 
-        // execute tasks
-        for (unsigned i = 0; i < batches.size(); ++i)
+        data[i] = utils::random::buffer(size);
+        file.push_back(utils::temp::File(data[i]));
+
+        std::vector<char> dst(size);
+        buffers[i] = dst;
+
+        total_bytes[i] = 0;
+        covered[i].resize(size);
+
+        paths.push_back(file[i].path);
+        file_offsets.push_back(0);
+        bytesizes.push_back(size);
+        dsts.push_back(buffers[i].data());
+    }
+    {
+        MultiFileWorkloadAssigner assigner(paths, file_offsets, bytesizes, dsts, config);
+
+        EXPECT_GT(assigner.file_assignments(0).size(), 0);
+        if (num_files == 1)
         {
-            auto & batch = batches[i];
-            for (auto & task : batch.tasks)
+            EXPECT_EQ(assigner.file_assignments(0).size(), config->concurrency);
+        }
+
+        // create internal division to divide the file into requests (each request represent a tensor)
+
+        for (unsigned file_idx = 0; file_idx < num_files; ++file_idx)
+        {
+            auto chunks = utils::random::chunks(bytesizes[file_idx], num_chunks[file_idx]);
+            EXPECT_EQ(chunks.size(), num_chunks[file_idx]);
+            auto total_chunks_size = std::accumulate(chunks.begin(), chunks.end(), 0u);
+            EXPECT_EQ(total_chunks_size, bytesizes[file_idx]);
+
+            Batches batches(utils::random::number(), assigner.file_assignments(file_idx), config, responder, file[file_idx].path, s3_params, 0, bytesizes[file_idx], chunks);
+
+            // execute tasks
+            for (unsigned i = 0; i < batches.size(); ++i)
             {
-                total_bytes += task.info.bytesize;
-                for (unsigned j = task.info.offset; j < task.info.end; ++j)
+                auto & batch = batches[i];
+                for (auto & task : batch.tasks)
                 {
-                    covered[j] += 1;
+                    total_bytes[file_idx] += task.info.bytesize;
+                    for (unsigned j = task.info.offset; j < task.info.end; ++j)
+                    {
+                        covered[file_idx][j] += 1;
+                    }
                 }
+
+                batch.finished_until(batch.range.end);
             }
 
-            batch.finished_until(batch.range.end);
+            for (unsigned i = 0; i < num_chunks[file_idx]; ++i)
+            {
+                expected_responses[file_idx].insert(i);
+            }
         }
     }
 
     // wait for all the requests to finish
-    std::set<int> expected_responses;
 
-    for (unsigned i = 0; i < num_chunks; ++i)
+    for (unsigned file_idx = 0; file_idx < num_files; ++file_idx)
     {
-        expected_responses.insert(i);
+        for (unsigned i = 0; i < num_chunks[file_idx]; ++i)
+        {
+            const auto r = responder->pop();
+            EXPECT_EQ(r.ret, common::ResponseCode::Success);
+            EXPECT_EQ(expected_responses[file_idx].count(r.index), 1);
+            expected_responses[file_idx].erase(r.index);
+        }
+        EXPECT_TRUE(expected_responses[file_idx].empty());
     }
 
-    for (unsigned i = 0; i < num_chunks; ++i)
-    {
-        const auto r = responder->pop();
-        EXPECT_EQ(r.ret, common::ResponseCode::Success);
-        EXPECT_EQ(expected_responses.count(r.index), 1);
-        expected_responses.erase(r.index);
-    }
-
-    EXPECT_TRUE(expected_responses.empty());
     auto r = responder->pop();
     EXPECT_EQ(r.ret, common::ResponseCode::FinishedError);
 
     // verify that the entire range is covered
-    EXPECT_EQ(total_bytes, size);
-    for (auto byte : covered)
+    for (unsigned file_idx = 0; file_idx < num_files; ++file_idx)
     {
-        EXPECT_EQ(byte, 1);
+        EXPECT_EQ(total_bytes[file_idx], bytesizes[file_idx]);
+        for (auto byte : covered[file_idx])
+        {
+            EXPECT_EQ(byte, 1);
+        }
     }
 }
 
@@ -104,7 +152,24 @@ TEST(Batches, Failed_Reader)
     try
     {
         common::s3::S3ClientWrapper::Params s3_params;
-        Batches batches(utils::random::number(), config, responder, utils::random::string(), s3_params, 0, size, dst.data(), num_chunks, chunks.data());
+
+        std::vector<std::string> paths;
+        std::vector<size_t> file_offsets;
+        std::vector<size_t> bytesizes;
+        std::vector<void*> dsts;
+
+        const auto file_path = utils::random::string();
+        paths.push_back(file_path);
+        file_offsets.push_back(0);
+        bytesizes.push_back(size);
+        dsts.push_back(dst.data());
+
+        MultiFileWorkloadAssigner assigner(paths, file_offsets, bytesizes, dsts, config);
+
+        EXPECT_GT(assigner.file_assignments(0).size(), 0);
+        EXPECT_EQ(assigner.file_assignments(0).size(), config->concurrency);
+
+        Batches batches(utils::random::number(), assigner.file_assignments(0), config, responder, file_path, s3_params, 0, size, chunks);
     }
     catch(const common::Exception & e)
     {
@@ -159,7 +224,23 @@ TEST(Batches, Zero_Size_Request)
 
     {
         common::s3::S3ClientWrapper::Params s3_params;
-        Batches batches(utils::random::number(), config, responder, file.path, s3_params, 0, size, dst.data(), num_chunks, chunks.data());
+
+        std::vector<std::string> paths;
+        std::vector<size_t> file_offsets;
+        std::vector<size_t> bytesizes;
+        std::vector<void*> dsts;
+
+        paths.push_back(file.path);
+        file_offsets.push_back(0);
+        bytesizes.push_back(size);
+        dsts.push_back(dst.data());
+
+        MultiFileWorkloadAssigner assigner(paths, file_offsets, bytesizes, dsts, config);
+
+        EXPECT_GT(assigner.file_assignments(0).size(), 0);
+        EXPECT_EQ(assigner.file_assignments(0).size(), config->concurrency);
+
+        Batches batches(utils::random::number(), assigner.file_assignments(0), config, responder, file.path, s3_params, 0, size, chunks);
 
         // execute tasks
         for (unsigned i = 0; i < batches.size(); ++i)

--- a/cpp/streamer/impl/batches/batches_test.cc
+++ b/cpp/streamer/impl/batches/batches_test.cc
@@ -35,7 +35,7 @@ TEST(Batches, Sanity)
 
     {
         common::s3::S3ClientWrapper::Params s3_params;
-        Batches batches(config, responder, file.path, s3_params, 0, size, dst.data(), num_chunks, chunks.data());
+        Batches batches(utils::random::number(), config, responder, file.path, s3_params, 0, size, dst.data(), num_chunks, chunks.data());
 
         // execute tasks
         for (unsigned i = 0; i < batches.size(); ++i)
@@ -104,7 +104,7 @@ TEST(Batches, Failed_Reader)
     try
     {
         common::s3::S3ClientWrapper::Params s3_params;
-        Batches batches(config, responder, utils::random::string(), s3_params, 0, size, dst.data(), num_chunks, chunks.data());
+        Batches batches(utils::random::number(), config, responder, utils::random::string(), s3_params, 0, size, dst.data(), num_chunks, chunks.data());
     }
     catch(const common::Exception & e)
     {
@@ -159,7 +159,7 @@ TEST(Batches, Zero_Size_Request)
 
     {
         common::s3::S3ClientWrapper::Params s3_params;
-        Batches batches(config, responder, file.path, s3_params, 0, size, dst.data(), num_chunks, chunks.data());
+        Batches batches(utils::random::number(), config, responder, file.path, s3_params, 0, size, dst.data(), num_chunks, chunks.data());
 
         // execute tasks
         for (unsigned i = 0; i < batches.size(); ++i)

--- a/cpp/streamer/impl/file/file.cc
+++ b/cpp/streamer/impl/file/file.cc
@@ -53,7 +53,7 @@ void File::read(size_t bytesize, char * buffer)
     }
 }
 
-void File::async_read(std::vector<common::Range> & ranges, char * buffer)
+void File::async_read(const common::s3::S3ClientWrapper::Params & params, std::vector<common::Range> & ranges, char * buffer)
 {
     LOG(ERROR) << "Not implemented";
     throw common::Exception(common::ResponseCode::UnknownError);

--- a/cpp/streamer/impl/file/file.h
+++ b/cpp/streamer/impl/file/file.h
@@ -21,7 +21,7 @@ struct File : Reader
 
     void seek(size_t offset) override;
 
-    void async_read(std::vector<common::Range> & ranges, char * buffer) override;
+    void async_read(const common::s3::S3ClientWrapper::Params & params, std::vector<common::Range> & ranges, char * buffer) override;
     common::Response async_response() override;
 
  private:

--- a/cpp/streamer/impl/reader/BUILD
+++ b/cpp/streamer/impl/reader/BUILD
@@ -5,5 +5,6 @@ runai_cc_auto_library(
     deps = [
          "//common/range",
          "//common/response",
+         "//common/s3_wrapper",
     ],
 )

--- a/cpp/streamer/impl/reader/reader.h
+++ b/cpp/streamer/impl/reader/reader.h
@@ -7,7 +7,7 @@
 
 #include "common/range/range.h"
 #include "common/response/response.h"
-
+#include "common/s3_wrapper/s3_wrapper.h"
 namespace runai::llm::streamer::impl
 {
 
@@ -30,7 +30,7 @@ struct Reader
 
     // asynchronous
 
-    virtual void async_read(std::vector<common::Range> & ranges, char * buffer) = 0;
+    virtual void async_read(const common::s3::S3ClientWrapper::Params & params, std::vector<common::Range> & ranges, char * buffer) = 0;
     virtual common::Response async_response() = 0;
 
     const Mode mode;

--- a/cpp/streamer/impl/request/request.cc
+++ b/cpp/streamer/impl/request/request.cc
@@ -9,10 +9,11 @@
 namespace runai::llm::streamer::impl
 {
 
-Request::Request(size_t offset, unsigned index, unsigned tasks, size_t bytesize) :
+Request::Request(size_t offset, unsigned index, unsigned tasks, size_t bytesize, char * dst) :
     offset(offset),
     index(index),
     bytesize(bytesize),
+    dst(dst),
     _tasks(tasks)
 {}
 

--- a/cpp/streamer/impl/request/request.h
+++ b/cpp/streamer/impl/request/request.h
@@ -19,7 +19,7 @@ namespace runai::llm::streamer::impl
 
 struct Request
 {
-    Request(size_t file_offset, unsigned index, unsigned tasks, size_t bytesize);
+    Request(size_t file_offset, unsigned index, unsigned tasks, size_t bytesize, char * dst);
 
     // return true if all the request's range had been read
     bool finished(common::ResponseCode result = common::ResponseCode::Success);
@@ -29,9 +29,13 @@ struct Request
     // offset in file
     const size_t offset;
 
+    // request index in the original list of file's sub ranges
     const unsigned index;
 
     const size_t bytesize;
+
+    // start offset in destination buffer
+    char * dst;
 
  private:
     // counter of unread chunks (each chunk is handled by a Task object)

--- a/cpp/streamer/impl/request/request_test.cc
+++ b/cpp/streamer/impl/request/request_test.cc
@@ -13,7 +13,7 @@ namespace runai::llm::streamer::impl
 TEST(Creation, Sanity)
 {
     unsigned num_tasks = utils::random::number(1, 10);
-    Request request(utils::random::number<size_t>(), utils::random::number(), num_tasks, utils::random::number<size_t>());
+    Request request(utils::random::number<size_t>(), utils::random::number(), num_tasks, utils::random::number<size_t>(), nullptr);
     std::atomic<unsigned int> finished = 0;
     unsigned retries = 5;
 

--- a/cpp/streamer/impl/s3/s3.cc
+++ b/cpp/streamer/impl/s3/s3.cc
@@ -29,9 +29,9 @@ void S3::read(size_t bytesize, char * buffer)
     throw common::Exception(common::ResponseCode::UnknownError);
 }
 
-void S3::async_read(std::vector<common::Range> & ranges, char * buffer)
+void S3::async_read(const common::s3::S3ClientWrapper::Params & params, std::vector<common::Range> & ranges, char * buffer)
 {
-    auto response_code = _client->async_read(ranges, _config.s3_block_bytesize, buffer);
+    auto response_code = _client->async_read(params, ranges, _config.s3_block_bytesize, buffer);
     if (response_code != common::ResponseCode::Success)
     {
         throw common::Exception(response_code);

--- a/cpp/streamer/impl/s3/s3.h
+++ b/cpp/streamer/impl/s3/s3.h
@@ -32,7 +32,7 @@ struct S3 : Reader
     void read(size_t bytesize, char * buffer) override;
     void seek(size_t offset) override;
 
-    void async_read(std::vector<common::Range> & ranges, char * buffer) override;
+    void async_read(const common::s3::S3ClientWrapper::Params & params, std::vector<common::Range> & ranges, char * buffer) override;
     common::Response async_response() override;
 
  private:

--- a/cpp/streamer/impl/streamer/BUILD
+++ b/cpp/streamer/impl/streamer/BUILD
@@ -3,8 +3,10 @@ load("//:rules.bzl", "runai_cc_auto_library", "runai_cc_test")
 runai_cc_auto_library(
     name = "streamer",
     deps = [
+        "//streamer/impl/assigner",
         "//streamer/impl/config",
         "//streamer/impl/batches",
+        "//streamer/impl/workload",
         "//common/responder",
         "//utils/threadpool",
         "//utils/fdlimit",

--- a/cpp/streamer/impl/streamer/streamer.cc
+++ b/cpp/streamer/impl/streamer/streamer.cc
@@ -5,11 +5,13 @@
 #include <numeric>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "utils/logging/logging.h"
 #include "utils/scope_guard/scope_guard.h"
 
-#include "streamer/impl/batches/batches.h"
+#include "streamer/impl/workload/workload.h"
+#include "streamer/impl/assigner/assigner.h"
 #include "common/exception/exception.h"
 
 namespace runai::llm::streamer::impl
@@ -20,9 +22,9 @@ Streamer::Streamer() : Streamer(Config())
 
 Streamer::Streamer(Config config) :
     _config(std::make_shared<Config>(config)),
-    _pool([&](Batch batch, std::atomic<bool> & stopped)
+    _pool([&](Workload workload, std::atomic<bool> & stopped)
         {
-            batch.execute(stopped);
+            workload.execute(stopped);
         }, _config->concurrency)
 {
     LOG(DEBUG) << config;
@@ -57,7 +59,24 @@ common::ResponseCode Streamer::request(const std::string & path, size_t file_off
 
     try
     {
-        create_request(path, file_offset, bytesize, dst, num_sizes, internal_sizes, credentials);
+        std::vector<std::string> paths;
+        std::vector<size_t> file_offsets;
+        std::vector<size_t> bytesizes;
+        std::vector<void *> dsts;
+        std::vector<unsigned> num_sizes_v;
+        std::vector<std::vector<size_t>> internal_sizes_vv;
+
+        paths.push_back(path);
+        file_offsets.push_back(file_offset);
+        bytesizes.push_back(bytesize);
+        dsts.push_back(dst);
+        num_sizes_v.push_back(num_sizes);
+
+        std::vector<size_t> internal_sizes_v(internal_sizes, internal_sizes + num_sizes);
+
+        internal_sizes_vv.push_back(internal_sizes_v);
+
+        request_multi(paths, file_offsets, bytesizes, dsts, num_sizes_v, internal_sizes_vv, credentials);
     }
     catch(const common::Exception & e)
     {
@@ -66,94 +85,6 @@ common::ResponseCode Streamer::request(const std::string & path, size_t file_off
     }
 
     return ret;
-}
-
-void Streamer::create_request(const std::string & path, size_t file_offset, size_t bytesize, void * dst, unsigned num_sizes, size_t * internal_sizes, const common::s3::Credentials & credentials)
-{
-    LOG(SPAM) << "Requested to read asynchronously " << bytesize << " bytes from " << path << " offset " << file_offset << " in " << num_sizes << " chunks";
-
-    if (bytesize == 0 && num_sizes == 0)
-    {
-        LOG(ERROR) << "Empty request - no response will be sent";
-        throw common::Exception(common::ResponseCode::EmptyRequestError);
-    }
-
-    if (num_sizes == 0 || bytesize == 0)
-    {
-        LOG(ERROR) << "Total bytes to read is " << bytesize << " but number of sub requests is " << num_sizes;
-        throw common::Exception(common::ResponseCode::InvalidParameterError);
-    }
-
-    if (dst == 0)
-    {
-        LOG(ERROR) << "Destination buffer is null";
-        throw common::Exception(common::ResponseCode::InvalidParameterError);
-    }
-
-    if (_responder && !_responder->finished())
-    {
-        LOG(ERROR) << "Previous request is still running";
-        throw common::Exception(common::ResponseCode::BusyError);
-    }
-
-    // expecting for total of num_sizes responses
-    _responder = std::make_shared<common::Responder>(num_sizes);
-
-    // cancel responder in case of an error - cancelled response will not delay sending the next request
-    utils::ScopeGuard __responder_release([&](){_responder->cancel();});
-
-    std::shared_ptr<common::s3::StorageUri> uri;
-    try
-    {
-        uri = std::make_shared<common::s3::StorageUri>(path);
-    }
-    catch(const std::exception& e)
-    {
-    }
-
-    if (uri != nullptr && _s3 == nullptr)
-    {
-        // adjust fd limit acording to concurrency
-        auto fd_limit = utils::get_cur_file_descriptors();
-        LOG(DEBUG) << "Process file descriptors limit is " << fd_limit << " and concurrency level is " << _config->concurrency;
-        const auto desired_fd_limit = _config->concurrency * 64;
-        if (fd_limit < desired_fd_limit)
-        {
-            if (desired_fd_limit > utils::get_max_file_descriptors())
-            {
-                LOG(ERROR) << "Insufficient file descriptors limit " << fd_limit << " for concurrency level " << _config->concurrency << " ; increase fd limit to " << desired_fd_limit << " or higher, depending on your application fd usage";
-                throw common::Exception(common::ResponseCode::InsufficientFdLimit);
-            }
-            LOG(INFO) << "Increasing fd soft limit to " << desired_fd_limit << " for concurrency level " << _config->concurrency;
-            _fd_limit = std::make_unique<utils::FdLimitSetter>(desired_fd_limit);
-        }
-        _s3_stop = std::make_unique<S3Stop>();
-        _s3 = std::make_unique<S3Cleanup>();
-    }
-
-    common::s3::S3ClientWrapper::Params params(uri, credentials);
-
-    Batches batches(_config, _responder, path, params, file_offset, bytesize, dst, num_sizes, internal_sizes);
-
-    if (batches.total() != bytesize)
-    {
-        LOG(ERROR) << "Total bytes to read " << bytesize << " is not equal to the sum of the sub ranges, which is " << batches.total();
-        throw common::Exception(common::ResponseCode::InvalidParameterError);
-    }
-
-    // send batches to threadpool
-    for (unsigned i = 0; i < batches.size(); ++i)
-    {
-        auto & batch = batches[i];
-        if (batch.tasks.size() == 0)
-        {
-            break;
-        }
-        LOG(DEBUG) << "sending " << batch.tasks.size() << " tasks to worker " << i << " total bytes " << batch.range.size << " range " << batch.range.start << " to " << batch.range.end;
-        _pool.push(std::move(batch));
-    }
-
-    __responder_release.cancel();
 }
 
 common::Response Streamer::response()
@@ -172,7 +103,7 @@ common::ResponseCode Streamer::request_multi(
     std::vector<size_t> & bytesizes,
     std::vector<void *> & dsts,
     std::vector<unsigned> & num_sizes,
-    std::vector<size_t *> & internal_sizes,
+    std::vector<std::vector<size_t>> & internal_sizes,
     const common::s3::Credentials & credentials)
 {
     // verify input
@@ -192,17 +123,60 @@ common::ResponseCode Streamer::request_multi(
     // cancel responder in case of an error - cancelled response will not delay sending the next request
     utils::ScopeGuard __responder_release([&](){_responder->cancel();});
 
+    std::vector<Workload> workloads(_config->concurrency);
+
+    // divide reading between workers
+    MultiFileWorkloadAssigner assigner(paths, file_offsets, bytesizes, dsts, _config);
+
+    // Create batches for each file
+
     for (size_t i = 0; i < paths.size(); ++i)
     {
-        handle_request(i, paths[i], file_offsets[i], bytesizes[i], num_sizes[i], internal_sizes[i], dsts[i], credentials);
+        auto params = handle_s3(i, paths[i], credentials);
+        LOG(DEBUG) << "Creating batches for file index " << i << " path: " <<  paths[i];
+        Batches batches(i, assigner.file_assignments(i), _config, _responder, paths[i], params, file_offsets[i], bytesizes[i], internal_sizes[i]);
+
+        for (size_t j = 0; j < batches.size(); ++j)
+        {
+            auto & batch = batches[j];
+            if (batch.tasks.size() == 0)
+            {
+                LOG(WARNING) << "Found empty batch " << batch;
+                continue;
+            }
+
+            const auto worker_index = batch.worker_index;
+
+            LOG(DEBUG) << "created " << batch.tasks.size() << " tasks for worker " << worker_index << " total bytes " << batch.range.size << " range " << batch.range.start << " to " << batch.range.end;
+
+            workloads[worker_index].batches.push_back(std::move(batch));
+        }
+    }
+
+    // send batches to threadpool
+    for (auto & workload : workloads)
+    {
+        if (workload.batches.size() > 0)
+        {
+            LOG(DEBUG) << "sending workload to worker with batches " << workload.batches.size();
+
+            _pool.push(std::move(workload));
+        }
     }
 
     __responder_release.cancel();
 
+    return common::ResponseCode::Success;
 }
 
-void verify_requests(std::vector<std::string> & paths, std::vector<size_t> & file_offsets, std::vector<size_t> & bytesizes, std::vector<unsigned> & num_sizes, std::vector<void *> & dsts)
+void Streamer::verify_requests(std::vector<std::string> & paths, std::vector<size_t> & file_offsets, std::vector<size_t> & bytesizes, std::vector<unsigned> & num_sizes, std::vector<void *> & dsts)
 {
+    if (dsts[0] == 0)
+    {
+        LOG(ERROR) << "Destination buffer is null";
+        throw common::Exception(common::ResponseCode::InvalidParameterError);
+    }
+
     for (size_t i = 0; i < paths.size(); ++i)
     {
         LOG(SPAM) << "Requested to read asynchronously " << bytesizes[i] << " bytes from " << paths[i] << " offset " << file_offsets[i] << " in " << num_sizes[i] << " chunks";
@@ -215,19 +189,13 @@ void verify_requests(std::vector<std::string> & paths, std::vector<size_t> & fil
 
         if (num_sizes[i] == 0 || bytesizes[i] == 0)
         {
-            LOG(ERROR) << "Total bytes to read is " << bytesizes[i] << " but number of sub requests is " << num_sizes;
-            throw common::Exception(common::ResponseCode::InvalidParameterError);
-        }
-
-        if (dsts[i] == 0)
-        {
-            LOG(ERROR) << "Destination buffer is null";
+            LOG(ERROR) << "Total bytes to read is " << bytesizes[i] << " but number of sub requests is " << num_sizes[i];
             throw common::Exception(common::ResponseCode::InvalidParameterError);
         }
     }
 }
 
-void Streamer::handle_request(unsigned file_index, const std::string & path, size_t file_offset, size_t bytesize, unsigned num_sizes, size_t * internal_sizes, void * dst, const common::s3::Credentials & credentials)
+common::s3::S3ClientWrapper::Params Streamer::handle_s3(unsigned file_index, const std::string & path, const common::s3::Credentials & credentials)
 {
     std::shared_ptr<common::s3::StorageUri> uri;
     try
@@ -258,27 +226,7 @@ void Streamer::handle_request(unsigned file_index, const std::string & path, siz
         _s3 = std::make_unique<S3Cleanup>();
     }
 
-    common::s3::S3ClientWrapper::Params params(uri, credentials);
-
-    Batches batches(_config, _responder, path, params, file_offset, bytesize, dst, num_sizes, internal_sizes);
-
-    if (batches.total() != bytesize)
-    {
-        LOG(ERROR) << "Total bytes to read " << bytesize << " is not equal to the sum of the sub ranges, which is " << batches.total();
-        throw common::Exception(common::ResponseCode::InvalidParameterError);
-    }
-
-    // send batches to threadpool
-    for (unsigned i = 0; i < batches.size(); ++i)
-    {
-        auto & batch = batches[i];
-        if (batch.tasks.size() == 0)
-        {
-            break;
-        }
-        LOG(DEBUG) << "sending " << batch.tasks.size() << " tasks to worker " << i << " total bytes " << batch.range.size << " range " << batch.range.start << " to " << batch.range.end;
-        _pool.push(std::move(batch));
-    }
+    return common::s3::S3ClientWrapper::Params(file_index, uri, credentials);
 }
 
 }; // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/streamer/streamer.cc
+++ b/cpp/streamer/impl/streamer/streamer.cc
@@ -134,7 +134,7 @@ common::ResponseCode Streamer::request_multi(
     {
         auto params = handle_s3(i, paths[i], credentials);
         LOG(DEBUG) << "Creating batches for file index " << i << " path: " <<  paths[i];
-        Batches batches(i, assigner.file_assignments(i), _config, _responder, paths[i], params, file_offsets[i], bytesizes[i], internal_sizes[i]);
+        Batches batches(i, assigner.file_assignments(i), _config, _responder, paths[i], params, bytesizes[i], internal_sizes[i]);
 
         for (size_t j = 0; j < batches.size(); ++j)
         {

--- a/cpp/streamer/impl/streamer/streamer.cc
+++ b/cpp/streamer/impl/streamer/streamer.cc
@@ -135,8 +135,9 @@ common::ResponseCode Streamer::request_multi(
         auto params = handle_s3(i, paths[i], credentials);
         LOG(DEBUG) << "Creating batches for file index " << i << " path: " <<  paths[i];
         Batches batches(i, assigner.file_assignments(i), _config, _responder, paths[i], params, internal_sizes[i]);
-
-        for (size_t j = 0; j < batches.size(); ++j)
+        const auto num_batches = batches.size();
+        LOG(DEBUG) << "Created " << num_batches << " batches for file index " << i;
+        for (size_t j = 0; j < num_batches; ++j)
         {
             auto & batch = batches[j];
             if (batch.tasks.size() == 0)
@@ -147,9 +148,10 @@ common::ResponseCode Streamer::request_multi(
 
             const auto worker_index = batch.worker_index;
 
-            LOG(DEBUG) << "created " << batch.tasks.size() << " tasks for worker " << worker_index << " total bytes " << batch.range.size << " range " << batch.range.start << " to " << batch.range.end;
+            LOG(DEBUG) << "Batch: file index " << batch.file_index << " with " << batch.tasks.size() << " tasks for worker " << worker_index << " total bytes " << batch.range.size << " range " << batch.range.start << " to " << batch.range.end;
 
             const auto & result = workloads[worker_index].add_batch(std::move(batch));
+            LOG(DEBUG) << "Added batch to worker " << worker_index << " with result " << result;
             if (result != common::ResponseCode::Success)
             {
                 LOG(ERROR) << "Failed to add batch to worker " << worker_index << " error: " << result;

--- a/cpp/streamer/impl/streamer/streamer.cc
+++ b/cpp/streamer/impl/streamer/streamer.cc
@@ -126,7 +126,7 @@ common::ResponseCode Streamer::request_multi(
     std::vector<Workload> workloads(_config->concurrency);
 
     // divide reading between workers
-    MultiFileWorkloadAssigner assigner(paths, file_offsets, bytesizes, dsts, _config);
+    Assigner assigner(paths, file_offsets, bytesizes, dsts, _config);
 
     // Create batches for each file
 

--- a/cpp/streamer/impl/streamer/streamer.cc
+++ b/cpp/streamer/impl/streamer/streamer.cc
@@ -134,7 +134,7 @@ common::ResponseCode Streamer::request_multi(
     {
         auto params = handle_s3(i, paths[i], credentials);
         LOG(DEBUG) << "Creating batches for file index " << i << " path: " <<  paths[i];
-        Batches batches(i, assigner.file_assignments(i), _config, _responder, paths[i], params, bytesizes[i], internal_sizes[i]);
+        Batches batches(i, assigner.file_assignments(i), _config, _responder, paths[i], params, internal_sizes[i]);
 
         for (size_t j = 0; j < batches.size(); ++j)
         {

--- a/cpp/streamer/impl/streamer/streamer.cc
+++ b/cpp/streamer/impl/streamer/streamer.cc
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <memory>
+#include <numeric>
 #include <string>
 #include <utility>
 
@@ -163,6 +164,121 @@ common::Response Streamer::response()
     }
 
     return _responder->pop();
+}
+
+common::ResponseCode Streamer::request_multi(
+    std::vector<std::string> & paths,
+    std::vector<size_t> & file_offsets,
+    std::vector<size_t> & bytesizes,
+    std::vector<void *> & dsts,
+    std::vector<unsigned> & num_sizes,
+    std::vector<size_t *> & internal_sizes,
+    const common::s3::Credentials & credentials)
+{
+    // verify input
+    verify_requests(paths, file_offsets, bytesizes, num_sizes, dsts);
+
+    auto total_sizes =  std::accumulate(num_sizes.begin(), num_sizes.end(), 0u);
+
+    if (_responder && !_responder->finished())
+    {
+        LOG(ERROR) << "Previous request is still running";
+        throw common::Exception(common::ResponseCode::BusyError);
+    }
+
+    // expecting for total of num_sizes responses
+    _responder = std::make_shared<common::Responder>(total_sizes);
+
+    // cancel responder in case of an error - cancelled response will not delay sending the next request
+    utils::ScopeGuard __responder_release([&](){_responder->cancel();});
+
+    for (size_t i = 0; i < paths.size(); ++i)
+    {
+        handle_request(i, paths[i], file_offsets[i], bytesizes[i], num_sizes[i], internal_sizes[i], dsts[i], credentials);
+    }
+
+    __responder_release.cancel();
+
+}
+
+void verify_requests(std::vector<std::string> & paths, std::vector<size_t> & file_offsets, std::vector<size_t> & bytesizes, std::vector<unsigned> & num_sizes, std::vector<void *> & dsts)
+{
+    for (size_t i = 0; i < paths.size(); ++i)
+    {
+        LOG(SPAM) << "Requested to read asynchronously " << bytesizes[i] << " bytes from " << paths[i] << " offset " << file_offsets[i] << " in " << num_sizes[i] << " chunks";
+
+        if (bytesizes[i] == 0 && num_sizes[i] == 0)
+        {
+            LOG(ERROR) << "Empty request - no response will be sent";
+            throw common::Exception(common::ResponseCode::EmptyRequestError);
+        }
+
+        if (num_sizes[i] == 0 || bytesizes[i] == 0)
+        {
+            LOG(ERROR) << "Total bytes to read is " << bytesizes[i] << " but number of sub requests is " << num_sizes;
+            throw common::Exception(common::ResponseCode::InvalidParameterError);
+        }
+
+        if (dsts[i] == 0)
+        {
+            LOG(ERROR) << "Destination buffer is null";
+            throw common::Exception(common::ResponseCode::InvalidParameterError);
+        }
+    }
+}
+
+void Streamer::handle_request(unsigned file_index, const std::string & path, size_t file_offset, size_t bytesize, unsigned num_sizes, size_t * internal_sizes, void * dst, const common::s3::Credentials & credentials)
+{
+    std::shared_ptr<common::s3::StorageUri> uri;
+    try
+    {
+        uri = std::make_shared<common::s3::StorageUri>(path);
+    }
+    catch(const std::exception& e)
+    {
+    }
+
+    if (uri != nullptr && _s3 == nullptr)
+    {
+        // adjust fd limit acording to concurrency
+        auto fd_limit = utils::get_cur_file_descriptors();
+        LOG(DEBUG) << "Process file descriptors limit is " << fd_limit << " and concurrency level is " << _config->concurrency;
+        const auto desired_fd_limit = _config->concurrency * 64;
+        if (fd_limit < desired_fd_limit)
+        {
+            if (desired_fd_limit > utils::get_max_file_descriptors())
+            {
+                LOG(ERROR) << "Insufficient file descriptors limit " << fd_limit << " for concurrency level " << _config->concurrency << " ; increase fd limit to " << desired_fd_limit << " or higher, depending on your application fd usage";
+                throw common::Exception(common::ResponseCode::InsufficientFdLimit);
+            }
+            LOG(INFO) << "Increasing fd soft limit to " << desired_fd_limit << " for concurrency level " << _config->concurrency;
+            _fd_limit = std::make_unique<utils::FdLimitSetter>(desired_fd_limit);
+        }
+        _s3_stop = std::make_unique<S3Stop>();
+        _s3 = std::make_unique<S3Cleanup>();
+    }
+
+    common::s3::S3ClientWrapper::Params params(uri, credentials);
+
+    Batches batches(_config, _responder, path, params, file_offset, bytesize, dst, num_sizes, internal_sizes);
+
+    if (batches.total() != bytesize)
+    {
+        LOG(ERROR) << "Total bytes to read " << bytesize << " is not equal to the sum of the sub ranges, which is " << batches.total();
+        throw common::Exception(common::ResponseCode::InvalidParameterError);
+    }
+
+    // send batches to threadpool
+    for (unsigned i = 0; i < batches.size(); ++i)
+    {
+        auto & batch = batches[i];
+        if (batch.tasks.size() == 0)
+        {
+            break;
+        }
+        LOG(DEBUG) << "sending " << batch.tasks.size() << " tasks to worker " << i << " total bytes " << batch.range.size << " range " << batch.range.start << " to " << batch.range.end;
+        _pool.push(std::move(batch));
+    }
 }
 
 }; // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/streamer/streamer.h
+++ b/cpp/streamer/impl/streamer/streamer.h
@@ -49,8 +49,21 @@ struct Streamer
     // returns common::ResponseCode error if failed
     common::Response response();
 
+    common::ResponseCode request_multi(
+      std::vector<std::string> & paths,
+      std::vector<size_t> & file_offsets,
+      std::vector<size_t> & bytesizes,
+      std::vector<void *> & dsts,
+      std::vector<unsigned> & num_sizes,
+      std::vector<size_t *> & internal_sizes,
+      const common::s3::Credentials & credentials);
+ 
  private:
     void create_request(const std::string & path, size_t offset, size_t bytesize, void * dst, unsigned num_sizes, size_t * internal_sizes, const common::s3::Credentials & credentials);
+
+    void Streamer::handle_request(unsigned file_index, const std::string & path, size_t file_offset, size_t bytesize, unsigned num_sizes, size_t * internal_sizes, void * dst, const common::s3::Credentials & credentials);
+
+    void verify_requests(std::vector<std::string> & paths, std::vector<size_t> & file_offsets, std::vector<size_t> & bytesizes, std::vector<unsigned> & num_sizes, std::vector<void *> & dsts);
 
  private:
     std::shared_ptr<const Config> _config;

--- a/cpp/streamer/impl/streamer/streamer_test.cc
+++ b/cpp/streamer/impl/streamer/streamer_test.cc
@@ -284,21 +284,6 @@ TEST(Async, End_Of_File_Error)
     const auto data = utils::random::buffer(chunk_size);
     utils::temp::File file(data);
 
-    size_t num_blocks = chunk_size/block_size;
-    size_t successful_bytesize = num_blocks * block_size;
-    size_t total = 0;
-    unsigned expected = 0;
-
-    while (total < successful_bytesize && expected < num_chunks)
-    {
-        total += chunks[expected];
-        if (total > successful_bytesize)
-        {
-            break;
-        }
-        ++expected;
-    }
-
     Config config(utils::random::number(1, 20), chunk_size, block_size, false /* do not enforce minimum */);
     Streamer streamer(config);
 
@@ -316,7 +301,7 @@ TEST(Async, End_Of_File_Error)
     for (unsigned i = 0; i < num_chunks; ++i)
     {
         const auto r = streamer.response();
-        LOG(SPAM) << "received response of request " << r.index;
+        LOG(SPAM) << "received response of request " << r.index << " : " << r.ret;
         if (r.ret == common::ResponseCode::Success)
         {
             ++count_successful;
@@ -326,7 +311,7 @@ TEST(Async, End_Of_File_Error)
             EXPECT_EQ(r.ret, common::ResponseCode::EofError);
         }
     }
-    EXPECT_EQ(count_successful, expected);
+    EXPECT_LT(count_successful, num_chunks);
 
     auto r = streamer.response();
     EXPECT_EQ(r.ret, common::ResponseCode::FinishedError);

--- a/cpp/streamer/impl/task/task.cc
+++ b/cpp/streamer/impl/task/task.cc
@@ -6,14 +6,15 @@
 namespace runai::llm::streamer::impl
 {
 
-Task::Info::Info(size_t offset, size_t bytesize) :
+Task::Info::Info(size_t offset, size_t bytesize, size_t relative_offset) :
     offset(offset),
     bytesize(bytesize),
-    end(offset + bytesize)
+    end(offset + bytesize),
+    relative_offset(relative_offset)
 {}
 
-Task::Task(std::shared_ptr<Request> request, size_t offset, size_t bytesize) :
-    Task(request, Info(offset, bytesize))
+Task::Task(std::shared_ptr<Request> request, size_t offset, size_t bytesize, size_t relative_offset) :
+    Task(request, Info(offset, bytesize, relative_offset))
 {}
 
 Task::Task(std::shared_ptr<Request> request, Info && info) :
@@ -34,10 +35,15 @@ bool Task::finished_request(common::ResponseCode ret)
     return request->finished(ret);
 }
 
+char * Task::destination() const
+{
+    ASSERT(request != nullptr) << "Request not initialized";
+    return request->dst + info.relative_offset;
+}
 
 std::ostream & operator<<(std::ostream & os, const Task & task)
 {
-    os << "task to read " << task.info.bytesize << " bytes from file offset " << task.info.offset << " to " << task.info.end;
+    os << "task to read " << task.info.bytesize << " bytes from file offset " << task.info.offset << " to " << task.info.end << " offset (relative to request start) " << task.info.relative_offset;
     return os;
 }
 

--- a/cpp/streamer/impl/task/task.h
+++ b/cpp/streamer/impl/task/task.h
@@ -29,6 +29,11 @@ struct Task
 
     std::shared_ptr<Request> request;
     Info info;
+
+    // Destination information for the worker
+    char * destination_base;      // Base address for the *request's* data buffer
+    size_t destination_offset;   // Offset from destination_base where *this task* should write
+
  private:
     bool _finished = false;
 };

--- a/cpp/streamer/impl/task/task.h
+++ b/cpp/streamer/impl/task/task.h
@@ -16,23 +16,26 @@ struct Task
     // file offsets to read
     struct Info
     {
-        Info(size_t offset, size_t bytesize);
+        Info(size_t offset, size_t bytesize, size_t relative_offset);
+        // offset from the beginning of the file
         size_t offset;
+        // number of bytes to read
         size_t bytesize;
+        // end from the beginning of the file
         size_t end;
+        // relative offset from the beginning of the request (e.g. zero for the request's first task)
+        size_t relative_offset;
     };
 
     Task(std::shared_ptr<Request> request, Info && info);
-    Task(std::shared_ptr<Request> request, size_t offset, size_t bytesize);
+    Task(std::shared_ptr<Request> request, size_t offset, size_t bytesize, size_t relative_offset);
 
     bool finished_request(common::ResponseCode ret);
 
+    char * destination() const;
+
     std::shared_ptr<Request> request;
     Info info;
-
-    // Destination information for the worker
-    char * destination_base;      // Base address for the *request's* data buffer
-    size_t destination_offset;   // Offset from destination_base where *this task* should write
 
  private:
     bool _finished = false;

--- a/cpp/streamer/impl/workload/BUILD
+++ b/cpp/streamer/impl/workload/BUILD
@@ -3,7 +3,12 @@ load("//:rules.bzl", "runai_cc_auto_library")
 runai_cc_auto_library(
     name = "workload",
     deps = [
-        "//streamer/impl/batch",
         "//utils/logging",
+        "//common/s3_wrapper",
+        "//common/exception",
+        "//common/response_code",
+        "//streamer/impl/batch",
+        "//streamer/impl/s3",
+        "//streamer/impl/reader",
     ],
 )

--- a/cpp/streamer/impl/workload/BUILD
+++ b/cpp/streamer/impl/workload/BUILD
@@ -1,0 +1,9 @@
+load("//:rules.bzl", "runai_cc_auto_library")
+
+runai_cc_auto_library(
+    name = "workload",
+    deps = [
+        "//streamer/impl/batch",
+        "//utils/logging",
+    ],
+)

--- a/cpp/streamer/impl/workload/workload.cc
+++ b/cpp/streamer/impl/workload/workload.cc
@@ -1,0 +1,18 @@
+
+#include "streamer/impl/workload/workload.h"
+
+#include "utils/logging/logging.h";
+
+namespace runai::llm::streamer::impl
+{
+
+void Workload::execute(std::atomic<bool> & stopped)
+{
+    for (auto & batch : batches)
+    {
+        batch.execute(stopped);
+        LOG(DEBUG) << "Finished batch " << batch;
+    }
+}
+
+}; // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/workload/workload.cc
+++ b/cpp/streamer/impl/workload/workload.cc
@@ -1,7 +1,7 @@
 
 #include "streamer/impl/workload/workload.h"
 
-#include "utils/logging/logging.h";
+#include "utils/logging/logging.h"
 
 namespace runai::llm::streamer::impl
 {

--- a/cpp/streamer/impl/workload/workload.cc
+++ b/cpp/streamer/impl/workload/workload.cc
@@ -21,17 +21,19 @@ size_t Workload::size() const
 
 common::ResponseCode Workload::add_batch(Batch && batch)
 {
-    _batches.push_back(std::move(batch));
-    _batches_by_file_index[batch.file_index] = &_batches.back();
 
-    if (_batches.size() == 1)
+    if (_batches.size() == 0)
     {
-        _params = _batches.front().params;
+        _params = batch.params;
     }
     else
     {
         return verify_batch(batch.params);
     }
+
+    _batches.push_back(std::move(batch));
+    _batches_by_file_index[batch.file_index] = &_batches.back();
+    
     return common::ResponseCode::Success;
 }
 
@@ -39,7 +41,7 @@ common::ResponseCode Workload::verify_batch(const common::s3::S3ClientWrapper::P
 {
     if (_params.valid() != params.valid())
     {
-        LOG(ERROR) << "Workload contains paths of different storage backends";
+         LOG(ERROR) << "Workload contains paths of different storage backends";
 
         return common::ResponseCode::InvalidParameterError;
     }

--- a/cpp/streamer/impl/workload/workload.cc
+++ b/cpp/streamer/impl/workload/workload.cc
@@ -1,18 +1,146 @@
 
 #include "streamer/impl/workload/workload.h"
 
+#include <memory>
+#include <utility>
+
+#include "streamer/impl/s3/s3.h"
+
+#include "common/response_code/response_code.h"
+#include "common/exception/exception.h"
+
 #include "utils/logging/logging.h"
 
 namespace runai::llm::streamer::impl
 {
 
+size_t Workload::size() const
+{
+    return _batches.size();
+}
+
+common::ResponseCode Workload::add_batch(Batch && batch)
+{
+    _batches.push_back(std::move(batch));
+    _batches_by_file_index[batch.file_index] = &_batches.back();
+
+    if (_batches.size() == 1)
+    {
+        _params = _batches.front().params;
+    }
+    else
+    {
+        return verify_batch(batch.params);
+    }
+    return common::ResponseCode::Success;
+}
+
+common::ResponseCode Workload::verify_batch(const common::s3::S3ClientWrapper::Params & params)
+{
+    if (_params.valid() != params.valid())
+    {
+        LOG(ERROR) << "Workload contains paths of different storage backends";
+
+        return common::ResponseCode::InvalidParameterError;
+    }
+    if (_params.valid() && params.uri->bucket != _params.uri->bucket)
+    {
+        LOG(ERROR) << "Workload contains paths of different buckets";
+        return common::ResponseCode::InvalidParameterError;
+    }
+
+    return common::ResponseCode::Success;
+}
+
 void Workload::execute(std::atomic<bool> & stopped)
 {
-    for (auto & batch : batches)
+    if (_batches.empty())
     {
-        batch.execute(stopped);
-        LOG(DEBUG) << "Finished batch " << batch;
+        return;
     }
+
+    // create reader
+    if (_params.valid())
+    {
+        async_read(stopped);
+    }
+    else
+    {
+        for (auto & batch : _batches)
+        {
+            batch.execute(stopped);
+            LOG(DEBUG) << "Finished batch " << batch;
+        }
+    }
+}
+
+void Workload::async_read(std::atomic<bool> & stopped)
+{
+    auto response_code = common::ResponseCode::Success;
+    try
+    {
+        const auto & config = *_batches.front().config;
+        auto s3_client = std::make_shared<common::s3::S3ClientWrapper>(_params);
+        _reader = std::make_shared<S3>(s3_client, config);
+        for (auto & batch : _batches)
+        {
+            LOG(DEBUG) << "Requesting batch " << batch;
+            _error_by_file_index[batch.file_index] = common::ResponseCode::Success;
+            batch.request(_reader, stopped);
+        }
+
+        LOG(DEBUG) << "Waiting for responses";
+
+        // wait for all the batched to finish
+        wait_for_responses(stopped);
+    }
+    catch(const common::Exception & e)
+    {
+        response_code = e.error();
+    }
+    catch (...)
+    {
+        response_code = common::ResponseCode::UnknownError;
+    }
+
+    for (auto & batch : _batches)
+    {
+        const auto error_code = (response_code == common::ResponseCode::Success ?  _error_by_file_index.at(batch.file_index) : response_code);
+        batch.handle_error(error_code);
+    }
+}
+
+void Workload::wait_for_responses(std::atomic<bool> & stopped)
+{
+    if (stopped)
+    {
+        throw common::Exception(common::ResponseCode::FinishedError);
+    }
+
+    // wait for responses from the reader
+    // stopped flag was propagated to the storage backend when the request was made, and the storage backend is responsible for returning FinishedError when stopped flag is set
+    while (true)
+    {
+        auto r = _reader->async_response();
+
+        LOG(SPAM) << "Received response " << r;
+
+        if (r.ret == common::ResponseCode::FinishedError)
+        {
+            throw common::Exception(common::ResponseCode::FinishedError);
+        }
+
+        auto batch = _batches_by_file_index.at(r.file_index);
+
+        if (r.ret != common::ResponseCode::Success)
+        {
+            _error_by_file_index[r.file_index] = r.ret;
+        }
+
+        batch->handle_response(r);
+    }
+
+    LOG(DEBUG) << "Finished reading files "  << (stopped ? " - terminated" : " successfully");
 }
 
 }; // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/workload/workload.h
+++ b/cpp/streamer/impl/workload/workload.h
@@ -3,8 +3,12 @@
 
 #include <atomic>
 #include <vector>
-
+#include <map>
+#include <memory>
 #include "streamer/impl/batch/batch.h"
+#include "streamer/impl/reader/reader.h"
+#include "common/s3_wrapper/s3_wrapper.h"
+#include "common/response_code/response_code.h"
 
 namespace runai::llm::streamer::impl
 {
@@ -17,7 +21,20 @@ struct Workload
 
     void execute(std::atomic<bool> & stopped);
 
-    std::vector<Batch> batches;
+    common::ResponseCode add_batch(Batch && batch);
+
+    size_t size() const;
+
+ private:
+    common::ResponseCode verify_batch(const common::s3::S3ClientWrapper::Params & params);
+    void wait_for_responses(std::atomic<bool> & stopped);
+    void async_read(std::atomic<bool> & stopped);
+ private:
+    std::vector<Batch> _batches;
+    std::map<unsigned, Batch *> _batches_by_file_index;
+    std::map<unsigned, common::ResponseCode> _error_by_file_index;
+    common::s3::S3ClientWrapper::Params _params;
+    std::shared_ptr<Reader> _reader;
 };
 
 }; // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/workload/workload.h
+++ b/cpp/streamer/impl/workload/workload.h
@@ -1,0 +1,23 @@
+
+#pragma once
+
+#include <atomic>
+#include <vector>
+
+#include "streamer/impl/batch/batch.h"
+
+namespace runai::llm::streamer::impl
+{
+
+struct Workload
+{
+    Workload() = default;
+    Workload(Workload &&) = default;
+    Workload & operator=(Workload &&) = default;
+
+    void execute(std::atomic<bool> & stopped);
+
+    std::vector<Batch> batches;
+};
+
+}; // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/workload/workload.h
+++ b/cpp/streamer/impl/workload/workload.h
@@ -30,8 +30,7 @@ struct Workload
     void wait_for_responses(std::atomic<bool> & stopped);
     void async_read(std::atomic<bool> & stopped);
  private:
-    std::vector<Batch> _batches;
-    std::map<unsigned, Batch *> _batches_by_file_index;
+    std::map<unsigned, Batch> _batches_by_file_index;
     std::map<unsigned, common::ResponseCode> _error_by_file_index;
     common::s3::S3ClientWrapper::Params _params;
     std::shared_ptr<Reader> _reader;

--- a/cpp/streamer/streamer.h
+++ b/cpp/streamer/streamer.h
@@ -71,6 +71,35 @@ _RUNAI_EXTERN_C int runai_request_with_credentials(
 
 _RUNAI_EXTERN_C int runai_response(void * streamer, unsigned * index /* return parameter */);
 
+// send asynchronous read request to read multiple files
+// Each file will be copied to its own memory buffer (dst) with a list of consecutive sub requests, and receive response for each sub request when ready
+// num_files : number of files to read
+// paths : list of files paths
+// file_offsets : offset for each file path, from which to start reading
+// bytesizes : size of each destination buffer
+// dsts : destination buffers
+// num_sizes : number of sub requests for each file
+// internal_sizes : a list containing the size of each sub request, where the first sub request starts at the given file offset and each sub request starts at the end of the previous one
+// return Success if request is valid
+
+_RUNAI_EXTERN_C int runai_request_multi(
+    void * streamer,
+    unsigned num_files,
+    const char ** paths,
+    size_t * file_offsets,
+    size_t * bytesizes,
+    void ** dsts,
+    unsigned * num_sizes,
+    size_t ** internal_sizes,
+    const char * key,
+    const char * secret,
+    const char * token,
+    const char * region,
+    const char * endpoint
+);
+
+_RUNAI_EXTERN_C int runai_response_multi(void * streamer, unsigned * file_index /* return parameter */, unsigned * index /* return parameter */);
+
 _RUNAI_EXTERN_C const char * runai_response_str(int response_code);
 
 } // namespace runai::llm::streamer

--- a/cpp/streamer/streamer.ldscript
+++ b/cpp/streamer/streamer.ldscript
@@ -7,6 +7,8 @@
         runai_request;
         runai_request_with_credentials;
         runai_response;
+        runai_request_multi;
+        runai_response_multi;
         runai_response_str;
     local: *;
 };

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/__init__.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/__init__.py
@@ -47,34 +47,57 @@ class LibstreamerDLLWrapper:
         self.fn_runai_request = self.lib.runai_request
         self.fn_runai_request.argtypes = [
             t_streamer,
-            ctypes.c_char_p,
-            ctypes.c_size_t,
-            ctypes.c_size_t,
-            ctypes.c_void_p,
-            ctypes.c_uint32,
-            ctypes.POINTER(ctypes.c_size_t),
+            ctypes.c_char_p, # path
+            ctypes.c_size_t, # file_offset
+            ctypes.c_size_t, # bytesize
+            ctypes.c_void_p, # dst
+            ctypes.c_uint32, # num_sizes
+            ctypes.POINTER(ctypes.c_size_t), # internal_sizes
         ]
         self.fn_runai_request.restype = ctypes.c_int
 
         self.fn_runai_request_with_credentials = self.lib.runai_request_with_credentials
         self.fn_runai_request_with_credentials.argtypes = [
             t_streamer,
-            ctypes.c_char_p,
-            ctypes.c_size_t,
-            ctypes.c_size_t,
-            ctypes.c_void_p,
-            ctypes.c_uint32,
-            ctypes.POINTER(ctypes.c_size_t),
-            ctypes.c_char_p,
-            ctypes.c_char_p,
-            ctypes.c_char_p,
-            ctypes.c_char_p,
+            ctypes.c_char_p, # path
+            ctypes.c_size_t, # file_offset
+            ctypes.c_size_t, # bytesize
+            ctypes.c_void_p, # dst
+            ctypes.c_uint32, # num_sizes
+            ctypes.POINTER(ctypes.c_size_t), # internal_sizes
+            ctypes.c_char_p, # key
+            ctypes.c_char_p, # secret
+            ctypes.c_char_p, # token
+            ctypes.c_char_p, # region
+            ctypes.c_char_p, # endpoint
         ]
         self.fn_runai_request_with_credentials.restype = ctypes.c_int
+
+        self.fn_runai_request_multi = self.lib.runai_request_multi
+        self.fn_runai_request_multi.argtypes = [
+            t_streamer, 
+            ctypes.c_uint32, # num_files
+            ctypes.POINTER(ctypes.c_char_p), # paths
+            ctypes.POINTER(ctypes.c_size_t), # file_offsets
+            ctypes.POINTER(ctypes.c_size_t), # bytesizes
+            ctypes.POINTER(ctypes.c_void_p), # dsts
+            ctypes.POINTER(ctypes.c_uint32), # num_sizes
+            ctypes.POINTER(ctypes.c_size_t), # internal_sizes
+            ctypes.c_char_p, # key
+            ctypes.c_char_p, # secret
+            ctypes.c_char_p, # token
+            ctypes.c_char_p, # region
+            ctypes.c_char_p, # endpoint
+        ]
+        self.fn_runai_request_multi.restype = ctypes.c_int
 
         self.fn_runai_response = self.lib.runai_response
         self.fn_runai_response.argtypes = [t_streamer, ctypes.POINTER(ctypes.c_uint32)]
         self.fn_runai_response.restype = ctypes.c_int
+
+        self.fn_runai_response_multi = self.lib.runai_response_multi
+        self.fn_runai_response_multi.argtypes = [t_streamer, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
+        self.fn_runai_response_multi.restype = ctypes.c_int
 
         self.fn_runai_response_str = self.lib.runai_response_str
         self.fn_runai_response_str.argtypes = [ctypes.c_int]

--- a/py/runai_model_streamer/runai_model_streamer/libstreamer/libstreamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/libstreamer/libstreamer.py
@@ -1,5 +1,5 @@
 from runai_model_streamer.libstreamer import dll, t_streamer
-from typing import List, Optional
+from typing import List, Optional, Tuple
 import ctypes
 
 from runai_model_streamer.s3_utils.s3_utils import (
@@ -77,19 +77,85 @@ def runai_request(
             f"Could not send runai_request_with_credentials to libstreamer due to: {runai_response_str(error_code)}"
         )
 
+def runai_request_multi(
+    streamer: t_streamer,
+    paths: List[str],
+    file_offsets: List[int],
+    bytesizes: List[int],
+    dsts: List[memoryview],
+    internal_sizes: List[List[int]],
+    s3_credentials: Optional[S3Credentials] = None,
+) -> None:
+    c_paths = (ctypes.c_char_p * len(paths))(*[path.encode("utf-8") for path in paths])
+    c_file_offsets = (ctypes.c_uint64 * len(file_offsets))(*file_offsets)
+    c_bytesizes = (ctypes.c_uint64 * len(bytesizes))(*bytesizes)
+    c_dsts = (ctypes.c_void_p * len(dsts))(*[dst.tobytes() for dst in dsts])
+ 
+    num_files = len(paths)
+
+    # c_num_sizes: An array where each element is the number of ranges for the corresponding file.
+    # Assuming the number of ranges fits into a c_uint32.
+    num_ranges_per_file_list = [len(sublist) for sublist in internal_sizes]
+    c_num_sizes = (ctypes.c_uint32 * num_files)(*num_ranges_per_file_list)
+
+    # c_internal_sizes: An array of pointers, where each pointer points to an array of actual range sizes.
+
+    # Create and store the actual ctypes arrays of range sizes.
+    _c_internal_sizes_data_arrays = [
+        (ctypes.c_uint64 * num_ranges_for_this_file)(*actual_sublist_data)
+        for num_ranges_for_this_file, actual_sublist_data in zip(num_ranges_per_file_list, internal_sizes)
+    ]
+
+    # Create the array of pointers that the C function expects.
+    PtrToUint64ArrayType = ctypes.POINTER(ctypes.c_uint64)
+    c_internal_sizes = (PtrToUint64ArrayType * num_files)()
+
+    # Populate this array of pointers.
+    for i, individual_c_array_obj in enumerate(_c_internal_sizes_data_arrays):
+        c_internal_sizes[i] = ctypes.cast(individual_c_array_obj, PtrToUint64ArrayType)
+    
+    error_code = dll.fn_runai_request_multi(
+        streamer,
+        len(paths),
+        c_paths,
+        c_file_offsets,
+        c_bytesizes,
+        c_dsts, 
+        c_num_sizes,
+        c_internal_sizes,
+        ctypes.c_char_p(s3_credentials.access_key_id.encode("utf-8")) if s3_credentials is not None and s3_credentials.access_key_id is not None else None,
+        ctypes.c_char_p(s3_credentials.secret_access_key.encode("utf-8")) if s3_credentials is not None and s3_credentials.secret_access_key is not None else None,
+        ctypes.c_char_p(s3_credentials.session_token.encode("utf-8")) if s3_credentials is not None and s3_credentials.session_token is not None else None,
+        ctypes.c_char_p(s3_credentials.region_name.encode("utf-8")) if s3_credentials is not None and s3_credentials.region_name is not None else None,
+        ctypes.c_char_p(s3_credentials.endpoint.encode("utf-8")) if s3_credentials is not None and s3_credentials.endpoint is not None else None,   
+    )
+    if error_code != SUCCESS_ERROR_CODE:
+        raise Exception(
+            f"Could not send runai_request_multi to libstreamer due to: {runai_response_str(error_code)}"
+        )
 
 def runai_response(streamer: t_streamer) -> Optional[int]:
     value = ctypes.c_uint32()
     error_code = dll.fn_runai_response(streamer, ctypes.byref(value))
     if error_code == FINISHED_ERROR_CODE:
         return None
-
     if error_code != SUCCESS_ERROR_CODE:
         raise Exception(
             f"Could not receive runai_response from libstreamer due to: {runai_response_str(error_code)}"
         )
     return value.value
 
+def runai_response_multi(streamer: t_streamer) -> Optional[Tuple[int, int]]:
+    file_index = ctypes.c_uint32()
+    range_index = ctypes.c_uint32()
+    error_code = dll.fn_runai_response_multi(streamer, ctypes.byref(file_index), ctypes.byref(range_index))
+    if error_code == FINISHED_ERROR_CODE:
+        return None
+    if error_code != SUCCESS_ERROR_CODE:
+        raise Exception(
+            f"Could not receive runai_response_multi from libstreamer due to: {runai_response_str(error_code)}"
+        )
+    return file_index.value, range_index.value
 
 def runai_response_str(response_code: int) -> str:
     return dll.fn_runai_response_str(response_code)


### PR DESCRIPTION
CPP layer for reading multiple files
The files are read into a single continuous memory segment

Added assigner to divide the reading equally between the workers - file is divided between workers only if the quota of a single worker is less than the file size

Assigner divides the files but is not aware to the internal division to sub ranges (tensors)
The Assigner generates one or more `AssignerWorkerTask` objects for each file

API of Batches has changed and it now accepts list of `AssignerWorkerTask`  objects of a single file.
Each `AssignerWorkerTask` is transformed into a Batch object that contains (as before) the internal division to sub ranges

The implementation and API of libstreamers3 also changes:
The S3 client handles requests from multiple files concurrently
A worker executing a Workload now requests reading for all the batches (i.e. files) and then wait for responses of all the requests. Namely, the same S3 client of the worker is reading all the files together.

The API will be changed later on again for  #51 