### PR TITLE
Fix the default value of RUNAI_STREAMER_CONCURRENCY

### DIFF
--- a/docs/src/env-vars.md
+++ b/docs/src/env-vars.md
@@ -10,7 +10,7 @@ Positive integer value
 
 #### Default value
 
-20
+16
 
 ### RUNAI_STREAMER_CHUNK_BYTESIZE
 


### PR DESCRIPTION
The default value of `RUNAI_STREAMER_CONCURRENCY` is 16.
Code: https://github.com/run-ai/runai-model-streamer/blob/master/cpp/streamer/impl/config/config.cc#L37