### PR TITLE
upgrade aws version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -106,11 +106,12 @@ RUN curl -fsSL -o zlib-1.3.1.tar.gz https://github.com/madler/zlib/releases/down
 
 ADD aarch64-linux-gnu.cmake /opt/toolchains/aarch64-linux-gnu.cmake
 ADD x86_64-linux-gnu.cmake /opt/toolchains/x86_64-linux-gnu.cmake
-RUN git clone --recurse-submodules --depth 1 --branch "1.11.321" https://github.com/aws/aws-sdk-cpp /opt/aws-sdk-cpp && \
+RUN git clone --recurse-submodules --depth 1 --branch "1.11.584" https://github.com/aws/aws-sdk-cpp /opt/aws-sdk-cpp && \
     cd /opt/aws-sdk-cpp && \
     
     cmake -DCMAKE_TOOLCHAIN_FILE=/opt/toolchains/x86_64-linux-gnu.cmake \
           -DBUILD_ONLY="s3-crt" \
+          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
           -DCMAKE_PREFIX_PATH="/opt/x86_64-ssl;/opt/x86_64-curl" \
           -DCMAKE_INSTALL_PREFIX="/opt/x86_64-aws" \
           -DFORCE_SHARED_CRT=OFF \
@@ -133,6 +134,7 @@ RUN git clone --recurse-submodules --depth 1 --branch "1.11.321" https://github.
     
     cmake -DCMAKE_TOOLCHAIN_FILE=/opt/toolchains/aarch64-linux-gnu.cmake \
           -DBUILD_ONLY="s3-crt" \
+          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
           -DCMAKE_PREFIX_PATH="/opt/aarch64-ssl;/opt/aarch64-curl" \
           -DCMAKE_INSTALL_PREFIX="/opt/aarch64-aws" \
           -DFORCE_SHARED_CRT=OFF \

--- a/cpp/streamer/impl/batches/batches.h
+++ b/cpp/streamer/impl/batches/batches.h
@@ -51,7 +51,7 @@ struct Batches
     // create tasks of a given request
     void handle_request(std::vector<Tasks> & v_tasks, unsigned request_index, size_t request_file_offset, size_t request_size);
 
-    unsigned _size;
+    unsigned _concurrency;
 
     BatchItr _itr;
 

--- a/cpp/streamer/impl/config/config.cc
+++ b/cpp/streamer/impl/config/config.cc
@@ -8,8 +8,9 @@
 namespace runai::llm::streamer::impl
 {
 
-Config::Config(unsigned concurrency, size_t s3_block_bytesize, size_t fs_block_bytesize, bool enforce_minimum) :
+Config::Config(unsigned concurrency, unsigned s3_concurrency, size_t s3_block_bytesize, size_t fs_block_bytesize, bool enforce_minimum) :
     concurrency(concurrency),
+    s3_concurrency(s3_concurrency),
     s3_block_bytesize(s3_block_bytesize),
     fs_block_bytesize(fs_block_bytesize)
 {
@@ -35,13 +36,19 @@ Config::Config(unsigned concurrency, size_t s3_block_bytesize, size_t fs_block_b
 
 Config::Config(bool enforce_minimum /* = true */) :
     Config(utils::getenv<unsigned long>("RUNAI_STREAMER_CONCURRENCY", 16UL),
+           utils::getenv<unsigned long>("RUNAI_STREAMER_CONCURRENCY", 8UL),
            utils::getenv<size_t>("RUNAI_STREAMER_CHUNK_BYTESIZE", common::s3::S3ClientWrapper::default_chunk_bytesize),
            utils::getenv<size_t>("RUNAI_STREAMER_CHUNK_BYTESIZE", min_fs_block_bytesize), enforce_minimum)
 {}
 
+unsigned Config::max_concurrency() const
+{
+    return std::max(concurrency, s3_concurrency);
+}
+
 std::ostream & operator<<(std::ostream & os, const Config & config)
 {
-    return os << "Streamer concurrency " << config.concurrency << " ; s3 block size " << config.s3_block_bytesize << " bytes; " << " ; file system block size " << config.fs_block_bytesize << " bytes; ";
+    return os << "Streamer concurrency " << config.concurrency << " ; s3 concurrency " << config.s3_concurrency << " ; s3 block size " << config.s3_block_bytesize << " bytes; " << " ; file system block size " << config.fs_block_bytesize << " bytes; ";
 }
 
 }; // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/config/config.h
+++ b/cpp/streamer/impl/config/config.h
@@ -16,12 +16,15 @@ namespace runai::llm::streamer::impl
 
 struct Config
 {
-    Config(unsigned concurrency, size_t s3_block_bytesize, size_t fs_block_bytesize, bool enforce_minimum = true);
+    Config(unsigned concurrency, unsigned s3_concurrency, size_t s3_block_bytesize, size_t fs_block_bytesize, bool enforce_minimum = true);
     Config(bool enforce_minimum = true);
+
+    unsigned max_concurrency() const;
 
     static constexpr size_t min_fs_block_bytesize = 2 * 1024 * 1024;
 
     unsigned concurrency;
+    unsigned s3_concurrency;
     size_t s3_block_bytesize;
     size_t fs_block_bytesize;
 };

--- a/cpp/streamer/impl/config/config_test.cc
+++ b/cpp/streamer/impl/config/config_test.cc
@@ -15,6 +15,7 @@ TEST(Creation, Default)
 {
     Config config;
     EXPECT_EQ(config.concurrency, 16UL);
+    EXPECT_EQ(config.s3_concurrency, 8UL);
     EXPECT_EQ(config.s3_block_bytesize, 8 * 1024 * 1024);
     EXPECT_EQ(config.fs_block_bytesize, 2 * 1024 * 1024);
 }
@@ -26,6 +27,7 @@ TEST(Creation, Concurrency)
 
     Config config;
     EXPECT_EQ(config.concurrency, expected);
+    EXPECT_EQ(config.s3_concurrency, expected);
     EXPECT_EQ(config.s3_block_bytesize, 8 * 1024 * 1024);
     EXPECT_EQ(config.fs_block_bytesize, 2 * 1024 * 1024);
 }
@@ -39,6 +41,7 @@ TEST(Creation, Chunk_Size)
         Config config;
 
         EXPECT_EQ(config.concurrency, 16UL);
+        EXPECT_EQ(config.s3_concurrency, 8UL);
         EXPECT_EQ(config.s3_block_bytesize, std::max(expected, min_));
         EXPECT_EQ(config.fs_block_bytesize, std::max(expected, Config::min_fs_block_bytesize));
     }


### PR DESCRIPTION
Upgraded to version 1.11.584

In the new version the `Aws::S3Crt::Model::GetObjectRequest` object is not copied when the request is sent, and should not be destroyed until the request is completed.

Added separate default value 8 for the concurrency level when reading from object storage
The concurrency level for file system remains 16 
The size of the thread pool is the maximal value, and the actual number of requests sent to the thread pool is according to the storage type 