### PR TITLE
Bugfix - zero array in test

### DIFF
--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
@@ -138,16 +138,20 @@ class FilesRequestsIterator:
             )
             if file_chunks_iterator.is_finished():
                 self.q.popleft()
-            elif len(file_chunks.chunks) == 0 or sum(file_chunks.chunks) == 0:
+            
+            if len(file_chunks.chunks) == 0 or sum(file_chunks.chunks) == 0:
                 break
 
             files_request.append(file_chunks)
             current_request_memory_size += sum(file_chunks.chunks)
 
+        if len(files_request.files) == 0:
+            files_request = None
         self.active_request = files_request
         return files_request
 
 class FileChunksIterator:
+
     def __init__(
         self, file_chunks: FileChunks
     ) -> None:

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_requests_iterator.py
@@ -171,6 +171,12 @@ class TestFilesRequestsIterator(unittest.TestCase):
         file_path, chunk_index = files_requests_iterator.get_global_file_and_chunk(0, 0)
         self.assertEqual(file_path, "a.txt")
         self.assertEqual(chunk_index, 2)
+    
+    def test_file_chunks_zero_chunks(self):
+        requests_iterator = FilesRequestsIterator(10, [FileChunks("a.txt", 10, [])])
+
+        res = requests_iterator.next_request()
+        self.assertIsNone(res)
 
 class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
     def test_memory_cap_unlimited(self):


### PR DESCRIPTION
In `tests/fuzzing/test_file_streamer.py`
We generated list of numbers, for example [5, 4, 2, ...] with random array size.
We took the first number as file offset and the rest as chunk array: 5, [4, 2, ...].
If we generated single item array, like [5], it would cause the request to be: 5, [].
Which caused the problem of "Could not parse buffer".

In addition I have made change so when the array is empty, the request iterator will return None, as there is nothing to send from that file, so no need to bother the CPP code