### PR TITLE
set default memory limit to be limited instead of unlimited

### DIFF
--- a/docs/src/env-vars.md
+++ b/docs/src/env-vars.md
@@ -43,7 +43,7 @@ Controls how the CPU Memory buffer to which tensors are read from the file is be
 
 #### Default value
 
-`-1 - UNLIMITED`
+`20000000000 - 20 GB`
 
 ### AWS_ENDPOINT_URL
 

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
@@ -8,7 +8,7 @@ import humanize
 
 
 RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME = "RUNAI_STREAMER_MEMORY_LIMIT"
-
+DEFAULT_MEMORY_LIMIT_STRING = "20000000000" # 20 GB
 
 class RunaiStreamerMemoryLimitException(Exception):
     pass
@@ -98,6 +98,8 @@ class FilesRequestsIteratorWithBuffer:
         files_chunks: List[FileChunks],
     ) -> FilesRequestsIteratorWithBuffer:
         memory_limit = os.getenv(RUNAI_STREAMER_MEMORY_LIMIT_ENV_VAR_NAME)
+        if memory_limit is None:
+            memory_limit = DEFAULT_MEMORY_LIMIT_STRING
         memory_mode = _get_memory_mode(memory_limit)
         if memory_limit is not None:
             memory_limit = int(memory_limit)
@@ -193,7 +195,7 @@ class ChunksIterator:
 
 
 def _get_memory_mode(memory_limit: str | None) -> MemoryCapMode:
-    if memory_limit is None or memory_limit == "-1":
+    if memory_limit == "-1":
         return MemoryCapMode.unlimited
     elif memory_limit == "0":
         return MemoryCapMode.largest_chunk


### PR DESCRIPTION
The default memory mode was changed to a limit of 20 GB instead of unlimited memory mode.

The motivation for the change is the integration of multiple files reading into vLLM, resulting in OOM for very large models.
Previously, when files were streamed one at a time, the maximal allocated memory buffer was the size of the largest file. However, if all the files are read in parallel, then in the unlimited memory mode the size of the allocated buffer would be the total size of the model weights  