### PR TITLE
Device type

### DIFF
--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
@@ -20,6 +20,8 @@ from runai_model_streamer.s3_utils.s3_utils import (
 
 import humanize
 
+import torch
+
 s3_credentials_module = get_s3_credentials_module()
 
 class RunaiStreamerInvalidInputException(Exception):
@@ -139,5 +141,9 @@ class FileStreamer:
                 return
             
             file_path, chunk_index, chunk_buffer = self.requests_iterator.get_global_file_and_chunk(file_relative_index, chunk_relative_index)
-            yield file_path, chunk_index, chunk_buffer
+            # create one dimensional tensor from the chunk buffer
+            # we return a tensor of shape (1, chunk_buffer.size)
+            # the data type of the original chunk_buffer, as created by the requests_iterator, is preserved (uint8)
+            tensor = torch.from_numpy(chunk_buffer).view(1, -1)
+            yield file_path, chunk_index, tensor
 

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
@@ -60,7 +60,7 @@ class FileStreamer:
         elapsed_time = timer() - self.start_time
         throughput = size / elapsed_time
         print(
-            f"[RunAI Streamer] Overall time to stream {humanize.naturalsize(size, binary=True)} of all files: {round(elapsed_time, 2)}s, {humanize.naturalsize(throughput, binary=True)}/s",
+            f"[RunAI Streamer] Overall time to stream {humanize.naturalsize(size, binary=True)} of all files to {self.device_str}: {round(elapsed_time, 2)}s, {humanize.naturalsize(throughput, binary=True)}/s",
             flush=True,
         )
         if self.streamer:
@@ -82,9 +82,16 @@ class FileStreamer:
             self,
             file_stream_requests: List[FileChunks],
             credentials: Optional[S3Credentials] = None,
+            device: Optional[str] = None,
 ) -> None:
         if not homogeneous_paths([file_stream_request.path for file_stream_request in file_stream_requests]):
             raise RunaiStreamerInvalidInputException("Cannot stream files from multiple source types in parallel") 
+
+        if device is None:
+            self.device_str = "cpu"
+        else:
+            self.device_str = device
+        self.device_type = torch.device(self.device_str)
 
         for file_stream_request in file_stream_requests:
             self.total_size += sum(file_stream_request.chunks)
@@ -145,5 +152,13 @@ class FileStreamer:
             # we return a tensor of shape (1, chunk_buffer.size)
             # the data type of the original chunk_buffer, as created by the requests_iterator, is preserved (uint8)
             tensor = torch.from_numpy(chunk_buffer).view(1, -1)
-            yield file_path, chunk_index, tensor
+
+            # currently file streamer is always reading a cpu buffer
+            # so we don't need to move the tensor to the device
+            # for future GDS/CUDA support we will need to move the tensor to the device (cpu or different device)
+            if self.device_str == "cpu":
+                yield file_path, chunk_index, tensor
+            else:
+                gpu_tensor = tensor.to(self.device_str)
+                yield file_path, chunk_index, gpu_tensor
 

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_file_streamer.py
@@ -30,7 +30,7 @@ class TestBindings(unittest.TestCase):
             for file, id, dst in fs.get_chunks():
                 self.assertEqual(file, file_path)
                 self.assertEqual(
-                    dst.tobytes().decode("utf-8"),
+                    dst.numpy().tobytes().decode("utf-8"),
                     id_to_results[id]["expected_text"],
                 )
 
@@ -53,7 +53,7 @@ class TestBindings(unittest.TestCase):
             for file, id, dst in fs.get_chunks():
                 self.assertEqual(file, file_path)
                 self.assertEqual(
-                    dst.tobytes().decode("utf-8"),
+                    dst.numpy().tobytes().decode("utf-8"),
                     id_to_results[id]["expected_text"],
                 )
 
@@ -85,7 +85,7 @@ class TestBindings(unittest.TestCase):
             for file, id, dst, in fs.get_chunks():
                 self.assertEqual(file, file_path)
                 self.assertEqual(
-                    dst.tobytes().decode("utf-8"),
+                    dst.numpy().tobytes().decode("utf-8"),
                     id_to_results[id]["expected_text"],
                 )
 

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_streamer.py
@@ -56,15 +56,21 @@ class SafetensorsStreamer:
             self,
             path: str,
             s3_credentials : Optional[S3Credentials] = None,
+            device: Optional[str] = None,
         ) -> None:
-        return self.stream_files([path], s3_credentials)
+        return self.stream_files([path], s3_credentials, device)
     
     def stream_files(
             self,
             paths: List[str],
             s3_credentials : Optional[S3Credentials] = None,
+            device: Optional[str] = None,
         ) -> None:
         self.files_to_tensors_metadata = {}
+        if device is None:
+            self.device_str = "cpu"
+        else:
+            self.device_str = device
 
         file_stream_requests: List[FileChunks] = []
 
@@ -78,6 +84,7 @@ class SafetensorsStreamer:
         self.file_streamer.stream_files(
             file_stream_requests,
             s3_credentials,
+            self.device_str,
         )
 
     def get_tensors(self) -> Iterator[torch.tensor]:

--- a/tests/fuzzing/test_file_streamer.py
+++ b/tests/fuzzing/test_file_streamer.py
@@ -86,7 +86,7 @@ class TestFuzzing(unittest.TestCase):
                 file_chunks = file_to_file_chunks[file]
                 expected_id_to_results = expected_file_to_id_to_results[file]
                 self.assertEqual(
-                    dst.tobytes(),
+                    dst.numpy().tobytes(),
                     expected_id_to_results[id]["expected_content"],
                 )
 


### PR DESCRIPTION
Add torch device type (string) as input parameter to `stream_files()`
The file streamer to return Pytorch tensor instead of ndarray
These changes are needed for the distributed streamer