### PR TITLE
Remove unnecessary boto3 import from GCS Credentials

### DIFF
--- a/py/runai_model_streamer_gcs/runai_model_streamer_gcs/credentials/credentials.py
+++ b/py/runai_model_streamer_gcs/runai_model_streamer_gcs/credentials/credentials.py
@@ -5,7 +5,6 @@ import google.auth
 import google.auth.credentials
 
 import os
-import boto3
 
 GCS_CREDENTIAL_TYPE = "GCS_CREDENTIAL_TYPE"
 GCS_SA_KEY_PATH = "GCS_SA_KEY_PATH"


### PR DESCRIPTION
Dependency fix: Remove `import boto3` from GCS credentials.py file. This package is not needed by `runai_model_streamer_gcs` package.