### PR TITLE
Remove old stream_file API

### DIFF
--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -14,7 +14,7 @@ from runai_model_streamer import SafetensorsStreamer
 file_path = "/path/to/file.safetensors"
 
 with SafetensorsStreamer() as streamer:
-    streamer.stream_file(file_path)
+    streamer.stream_files([file_path])
     for name, tensor in streamer.get_tensors():
         tensor.to('CUDA:0')
 ```

--- a/examples/stream_safetensors_from_custom_object_store.ipynb
+++ b/examples/stream_safetensors_from_custom_object_store.ipynb
@@ -133,7 +133,7 @@
     "    return\n",
     "\n",
     "with SafetensorsStreamer() as streamer:\n",
-    "    streamer.stream_file(file_path)\n",
+    "    streamer.stream_files([file_path])\n",
     "    for name, tensor in streamer.get_tensors():\n",
     "        heavy_workload(tensor)"
    ]

--- a/examples/stream_safetensors_from_gcs.ipynb
+++ b/examples/stream_safetensors_from_gcs.ipynb
@@ -144,7 +144,7 @@
     "    return\n",
     "\n",
     "with SafetensorsStreamer() as streamer:\n",
-    "    streamer.stream_file(file_path)\n",
+    "    streamer.stream_files([file_path])\n",
     "    for name, tensor in streamer.get_tensors():\n",
     "        heavy_workload(tensor)"
    ]

--- a/examples/stream_safetensors_from_s3.ipynb
+++ b/examples/stream_safetensors_from_s3.ipynb
@@ -124,7 +124,7 @@
     "    return\n",
     "\n",
     "with SafetensorsStreamer() as streamer:\n",
-    "    streamer.stream_file(file_path)\n",
+    "    streamer.stream_files([file_path])\n",
     "    for name, tensor in streamer.get_tensors():\n",
     "        heavy_workload(tensor)"
    ]

--- a/examples/stream_safetensors_to_cpu.ipynb
+++ b/examples/stream_safetensors_to_cpu.ipynb
@@ -55,7 +55,7 @@
     "    return\n",
     "\n",
     "with SafetensorsStreamer() as streamer:\n",
-    "    streamer.stream_file(file_path)\n",
+    "    streamer.stream_files([file_path])\n",
     "    for name, tensor in streamer.get_tensors():\n",
     "        heavy_workload(tensor)"
    ]

--- a/examples/stream_safetensors_to_gpu.ipynb
+++ b/examples/stream_safetensors_to_gpu.ipynb
@@ -50,7 +50,7 @@
     "file_path = \"model.safetensors\"\n",
     "\n",
     "with SafetensorsStreamer() as streamer:\n",
-    "    streamer.stream_file(file_path)\n",
+    "    streamer.stream_files([file_path])\n",
     "    for name, tensor in streamer.get_tensors():\n",
     "        gpu_tensor = tensor.to('CUDA:0')"
    ]

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_streamer.py
@@ -53,16 +53,6 @@ class SafetensorsStreamer:
     def __exit__(self, exc_type: any, exc_value: any, traceback: any) -> None:
         return self.file_streamer.__exit__(exc_type, exc_value, traceback)
 
-    def stream_file(
-            self,
-            path: str,
-            s3_credentials : Optional[S3Credentials] = None,
-            device: Optional[str] = "cpu",
-            is_distributed: bool = False,
-        ) -> None:
-        return self.stream_files([path], s3_credentials, device, is_distributed)
-
- 
     def stream_files(
             self,
             paths: List[str],

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/streamer_mock.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/streamer_mock.py
@@ -193,24 +193,16 @@ class StreamerPatcher:
         def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
             return self.original_streamer.__exit__(exc_type, exc_value, traceback)
 
-        def stream_file(self, path: str, s3_credentials: Optional[S3Credentials] = None,
-                          device: Optional[str] = "cpu", is_distributed: bool = False) -> None:
-            logger.debug(f"[RunAI Streamer][SHIM] stream_file is called with path: {path}")
-            self.files_to_tensors_metadata = {}
-            rewritten_path = self.patcher.convert_remote_path_to_local_path(path)
-            res = self.original_streamer.stream_file(
-                rewritten_path, s3_credentials, device, is_distributed
-            )
-            self.files_to_tensors_metadata = self.original_streamer.files_to_tensors_metadata
-            return res
-
         def stream_files(self, paths: List[str], s3_credentials: Optional[S3Credentials] = None,
                            device: Optional[str] = "cpu", is_distributed: bool = False) -> None:
             logger.debug(f"[RunAI Streamer][SHIM] stream_files is called")
+            self.files_to_tensors_metadata = {}
             rewritten_paths = [self.patcher.convert_remote_path_to_local_path(p) for p in paths]
-            return self.original_streamer.stream_files(
+            res = self.original_streamer.stream_files(
                 rewritten_paths, s3_credentials, device, is_distributed
             )
+            self.files_to_tensors_metadata = self.original_streamer.files_to_tensors_metadata
+            return res
 
         def get_tensors(self) -> Iterator[torch.tensor]:
             logger.debug(f"[RunAI Streamer][SHIM] get_tensors is called")

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/tests/dist_test_safetensors_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/tests/dist_test_safetensors_streamer.py
@@ -28,7 +28,7 @@ class TestDistributedSafetensorsStreamer(unittest.TestCase):
         env_vars = {"RUNAI_STREAMER_DIST": "1", "RUNAI_STREAMER_DIST_BUFFER_MIN_BYTESIZE": "0"}
         with unittest.mock.patch.dict(os.environ, env_vars):
             with SafetensorsStreamer() as run_sf:
-                run_sf.stream_file(file_path, None, "cpu", True)
+                run_sf.stream_files([file_path], None, "cpu", True)
                 for name, tensor in run_sf.get_tensors():
                     our[name] = tensor.clone().detach() # because distributed streamer has internal reusable buffer
 
@@ -64,7 +64,7 @@ class TestDistributedSafetensorsStreamer(unittest.TestCase):
         env_vars = {"RUNAI_STREAMER_DIST": "1", "RUNAI_STREAMER_DIST_BUFFER_MIN_BYTESIZE": "0"}
         with unittest.mock.patch.dict(os.environ, env_vars):
             with SafetensorsStreamer() as run_sf:
-                run_sf.stream_file(file_path, None, "cpu", False)
+                run_sf.stream_files([file_path], None, "cpu", False)
                 for name, tensor in run_sf.get_tensors():
                     our[name] = tensor.clone().detach() # because distributed streamer has internal reusable buffer
 

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/tests/test_mock.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/tests/test_mock.py
@@ -55,7 +55,7 @@ class TestSafetensorsStreamerMock(unittest.TestCase):
         our = {}
         with SafetensorsStreamer() as run_sf: # This call is now mocked
             # Pass the *fake* path here. The patcher will rewrite it.
-            run_sf.stream_file(fake_s3_path, None, "cpu")
+            run_sf.stream_files([fake_s3_path], None, "cpu")
             for name, tensor in run_sf.get_tensors():
                 our[name] = tensor
 
@@ -94,7 +94,7 @@ class TestSafetensorsStreamerMock(unittest.TestCase):
         # 4. Run streamer logic, passing the FAKE GS PATH
         our = {}
         with SafetensorsStreamer() as run_sf:
-            run_sf.stream_file(fake_gs_path, None, "cpu")
+            run_sf.stream_files([fake_gs_path], None, "cpu")
             for name, tensor in run_sf.get_tensors():
                 our[name] = tensor
 

--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/tests/test_safetensors_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/tests/test_safetensors_streamer.py
@@ -13,7 +13,7 @@ class TestSafetensorsStreamer(unittest.TestCase):
         file_path = os.path.join(file_dir, "test.safetensors")
         our = {}
         with SafetensorsStreamer() as run_sf:
-            run_sf.stream_file(file_path, None, "cpu")
+            run_sf.stream_files([file_path], None, "cpu")
             for name, tensor in run_sf.get_tensors():
                 our[name] = tensor
 


### PR DESCRIPTION
This PR removes the old stream_file API and keeps only the stream_files API in the python layer.