### PR TITLE
Refactor: Rename stream_file to stream_item

### DIFF
--- a/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/distributed_streamer/distributed_streamer.py
@@ -134,7 +134,7 @@ class DistributedStreamer:
         self.set_is_distributed(is_distributed, path, device)
 
         if not self.is_distributed:
-            self.file_streamer.stream_files(file_stream_requests, credentials, device)
+            self.file_streamer.stream_item(file_stream_requests, credentials, device)
         else:
             self.distributed_streamer.stream_files(file_stream_requests, credentials, device, self.params)
 
@@ -371,7 +371,7 @@ class _distributedStreamer:
                 logger.debug(f"[RunAI Streamer][Distributed] Setting memory limit to unlimited")
             if original_memory_limit == None:
                 os.environ["RUNAI_STREAMER_MEMORY_LIMIT"] = "-1"
-            self.file_streamer.stream_files(self.rank_file_chunks_list, credentials, "cpu")
+            self.file_streamer.stream_item(self.rank_file_chunks_list, credentials, "cpu")
         except Exception as e:
             raise e
         finally:

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/file_streamer.py
@@ -81,7 +81,7 @@ class FileStreamer:
         return path
 
 
-    def stream_files(
+    def stream_item(
             self,
             file_stream_requests: List[FileChunks],
             credentials: Optional[S3Credentials] = None,

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
@@ -24,7 +24,7 @@ class MemoryCapMode(enum.Enum):
 
 class FileChunks:
     def __init__(self, id: int, path: str, offset: int, chunks: List[int]) -> None:
-        self.id = id # the id of the file chunk must be unique in the context of a single stream_files request
+        self.id = id # the id of the file chunk must be unique in the context of a single stream_item request
         self.path = path
         self.offset = offset
         self.chunks = chunks

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_file_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_file_streamer.py
@@ -27,7 +27,7 @@ class TestBindings(unittest.TestCase):
             3: {"expected_text": "Test-Text3"},
         }
         with FileStreamer() as fs:
-            fs.stream_files([FileChunks(file_id, file_path, 1, request_sizes)])
+            fs.stream_item([FileChunks(file_id, file_path, 1, request_sizes)])
             for res_file_id, id, dst in fs.get_chunks():
                 self.assertEqual(res_file_id, file_id)
                 self.assertEqual(
@@ -51,7 +51,7 @@ class TestBindings(unittest.TestCase):
             2: {"expected_text": "Test-Text3"},
         }
         with FileStreamer() as fs:
-            fs.stream_files([FileChunks(file_id, file_path, 1, request_sizes)])
+            fs.stream_item([FileChunks(file_id, file_path, 1, request_sizes)])
             for res_file_id, id, dst in fs.get_chunks():
                 self.assertEqual(res_file_id, file_id)
                 self.assertEqual(
@@ -84,7 +84,7 @@ class TestBindings(unittest.TestCase):
             8: {"expected_text": "I"},
         }
         with FileStreamer() as fs:
-            fs.stream_files([FileChunks(file_id, file_path, 1, request_sizes)])
+            fs.stream_item([FileChunks(file_id, file_path, 1, request_sizes)])
             for res_file_id, id, dst, in fs.get_chunks():
                 self.assertEqual(res_file_id, file_id)
                 self.assertEqual(


### PR DESCRIPTION
Refactors the file_streamer layer by renaming the stream_file function to stream_item. This change is part of ongoing efforts to improve code clarity and consistency.