### PR TITLE
change pull_files to be recursive

### DIFF
--- a/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_streamer.py
+++ b/py/runai_model_streamer/runai_model_streamer/safetensors_streamer/safetensors_streamer.py
@@ -24,6 +24,10 @@ from runai_model_streamer.s3_utils.s3_utils import (
 SAFETENSORS_PATTERN = "*.safetensors"
 
 def list_safetensors(path: str, s3_credentials : Optional[S3Credentials] = None) -> List[str]:
+    """
+    List all safetensors files in the given path.
+    This function is not recursive.
+    """
     if is_s3_path(path):
         files = s3_glob(path, [SAFETENSORS_PATTERN], s3_credentials)
     elif is_gs_path(path):
@@ -38,6 +42,10 @@ def pull_files(model_path: str,
                 allow_pattern: Optional[List[str]] = None,
                 ignore_pattern: Optional[List[str]] = None,
                 s3_credentials : Optional[S3Credentials] = None) -> None:
+    """
+    Pull all safetensors files in the given path.
+    This function is recursive.
+    """
     if is_s3_path(model_path):
         return s3_pull_files(model_path, dst, allow_pattern, ignore_pattern, s3_credentials)
     if is_gs_path(model_path):

--- a/py/runai_model_streamer_gcs/runai_model_streamer_gcs/files/files.py
+++ b/py/runai_model_streamer_gcs/runai_model_streamer_gcs/files/files.py
@@ -32,7 +32,8 @@ def pull_files(model_path: str,
 
     bucket_name, base_dir, files = list_files(gcs, model_path,
                                                 allow_pattern,
-                                                ignore_pattern)
+                                                ignore_pattern,
+                                                recursive = True)
     if len(files) == 0:
         return
 
@@ -51,7 +52,8 @@ def list_files(
         gcs: storage.client.Client,
         path: str,
         allow_pattern: Optional[List[str]] = None,
-        ignore_pattern: Optional[List[str]] = None
+        ignore_pattern: Optional[List[str]] = None,
+        recursive: bool = False
 ) -> Tuple[str, str, List[str]]:
     parts = removeprefix(path, 'gs://').split('/')
     bucket_name = parts[0]
@@ -67,7 +69,7 @@ def list_files(
 
     # Use delimiter to control recursion
     # delimiter='/' stops at the next folder level
-    delimiter = '/'
+    delimiter = '/' if not recursive else None
     
     blobs = bucket.list_blobs(prefix=prefix, delimiter=delimiter)
     paths = [blob.name for blob in blobs]

--- a/py/runai_model_streamer_s3/runai_model_streamer_s3/files/files.py
+++ b/py/runai_model_streamer_s3/runai_model_streamer_s3/files/files.py
@@ -51,7 +51,8 @@ def pull_files(model_path: str,
 
     bucket_name, base_dir, files = list_files(s3, model_path,
                                                 allow_pattern,
-                                                ignore_pattern)
+                                                ignore_pattern,
+                                                recursive = True)
     if len(files) == 0:
         return
 
@@ -67,7 +68,8 @@ def list_files(
         s3,
         path: str,
         allow_pattern: Optional[List[str]] = None,
-        ignore_pattern: Optional[List[str]] = None
+        ignore_pattern: Optional[List[str]] = None,
+        recursive: bool = False
 ) -> Tuple[str, str, List[str]]:
     parts = removeprefix(path, 's3://').split('/')
     bucket_name = parts[0]
@@ -84,8 +86,11 @@ def list_files(
     op_parameters = {
         'Bucket': bucket_name,
         'Prefix': prefix,
-        'Delimiter': '/' # delimiter='/' so list is not recursive
     }
+
+    if not recursive:
+        # delimiter='/' so list is not recursive  
+        op_parameters['Delimiter'] = '/'
 
     paths = []
     for page in paginator.paginate(**op_parameters):


### PR DESCRIPTION
When we changed  `list_safetensors` to be non recursive, as required, `pull_files` was also changed to be non recursive.
However, integrating with vLLM and SGLang requires `pull_files` to be recursive.
This PR fixes `pull_files` to be recursive``