### PR TITLE
feat: add AZURE_STORAGE_ACCOUNT_KEY support for StorageSharedKeyCredential authentication

### DIFF
--- a/cpp/azure/azure.h
+++ b/cpp/azure/azure.h
@@ -8,20 +8,27 @@
 //
 // 1. Uri should be in the format az://container/path
 //
-// 2. Authentication using DefaultAzureCredential:
-//    - Set AZURE_STORAGE_ACCOUNT_NAME environment variable
-//    - DefaultAzureCredential tries multiple authentication methods in order:
-//      * Environment variables (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET) for service principal
-//      * Managed Identity (no env vars needed when running in Azure)
-//      * Azure CLI (az login)
-//      * Azure PowerShell (Connect-AzAccount)
-//      * Azure Developer CLI (azd auth login)
+// 2. Authentication methods (checked in this order):
+//    a. Connection string (Azurite testing only, requires AZURITE_TESTING build):
+//       - Set AZURE_STORAGE_CONNECTION_STRING environment variable
+//    b. Storage account key:
+//       - Set AZURE_STORAGE_ACCOUNT_NAME and AZURE_STORAGE_ACCOUNT_KEY environment variables
+//       - Uses StorageSharedKeyCredential
+//    c. DefaultAzureCredential:
+//       - Set AZURE_STORAGE_ACCOUNT_NAME environment variable
+//       - DefaultAzureCredential tries multiple authentication methods in order:
+//         * Environment variables (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET) for service principal
+//         * Managed Identity (no env vars needed when running in Azure)
+//         * Azure CLI (az login)
+//         * Azure PowerShell (Connect-AzAccount)
+//         * Azure Developer CLI (azd auth login)
 //
 // 3. For local testing with Azurite:
 //    - Use AZURE_STORAGE_CONNECTION_STRING environment variable
 //    - Run Azurite with --skipApiVersionCheck flag
 //
 // Example usage:
+// key-based: AZURE_STORAGE_ACCOUNT_NAME="account" AZURE_STORAGE_ACCOUNT_KEY="key" <streamer app> az://container/path
 // managed:   AZURE_STORAGE_ACCOUNT_NAME="account" <streamer app> az://container/path
 // azurite:   AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;..." <streamer app> az://container/path
 // programmatic: Pass credentials in ObjectClientConfig_t.initial_params

--- a/cpp/azure/client/client.cc
+++ b/cpp/azure/client/client.cc
@@ -11,6 +11,7 @@
 
 #include <azure/storage/blobs.hpp>
 #include <azure/identity/default_azure_credential.hpp>
+#include <azure/storage/common/storage_credential.hpp>
 #include <azure/core/exception.hpp>
 
 #include "azure/client/client.h"
@@ -32,6 +33,7 @@ AzureClient::AzureClient(const common::backend_api::ObjectClientConfig_t& config
 {
     // ClientConfiguration reads environment variables
     _account_name = _client_config.account_name;
+    _account_key = _client_config.account_key;
 #ifdef AZURITE_TESTING
     _connection_string = _client_config.connection_string;
 #endif
@@ -48,6 +50,10 @@ AzureClient::AzureClient(const common::backend_api::ObjectClientConfig_t& config
             if (strcmp(key, "account_name") == 0)
             {
                 _account_name = std::string(value);
+            }
+            else if (strcmp(key, "account_key") == 0)
+            {
+                _account_key = std::string(value);
             }
 #ifdef AZURITE_TESTING
             else if (strcmp(key, "connection_string") == 0)
@@ -87,15 +93,24 @@ AzureClient::AzureClient(const common::backend_api::ObjectClientConfig_t& config
         } else
 #endif
         if (_account_name.has_value()) {
-            // Use DefaultAzureCredential (managed identity, Azure CLI, environment variables, etc.)
-            // Reference: https://learn.microsoft.com/en-us/azure/developer/cpp/sdk/authentication
-            std::string url = "https://" + _account_name.value() + ".blob.core.windows.net";
-            // Share a single DefaultAzureCredential across all clients in the process to better
-            // utilize token caching and reduce chances of overwhelming authentication sources
-            // (e.g., IMDS) which can result in fatal throttling errors.
-            static auto credential = std::make_shared<Azure::Identity::DefaultAzureCredential>();
-            _blob_service_client = std::make_shared<BlobServiceClient>(url, credential, options);
-            LOG(DEBUG) << "Azure client initialized with DefaultAzureCredential for account: " << _account_name.value();
+            if (_account_key.has_value()) {
+                // Use StorageSharedKeyCredential (account name + account key)
+                std::string url = "https://" + _account_name.value() + ".blob.core.windows.net";
+                auto credential = std::make_shared<Azure::Storage::StorageSharedKeyCredential>(
+                    _account_name.value(), _account_key.value());
+                _blob_service_client = std::make_shared<BlobServiceClient>(url, credential, options);
+                LOG(DEBUG) << "Azure client initialized with StorageSharedKeyCredential for account: " << _account_name.value();
+            } else {
+                // Use DefaultAzureCredential (managed identity, Azure CLI, environment variables, etc.)
+                // Reference: https://learn.microsoft.com/en-us/azure/developer/cpp/sdk/authentication
+                std::string url = "https://" + _account_name.value() + ".blob.core.windows.net";
+                // Share a single DefaultAzureCredential across all clients in the process to better
+                // utilize token caching and reduce chances of overwhelming authentication sources
+                // (e.g., IMDS) which can result in fatal throttling errors.
+                static auto credential = std::make_shared<Azure::Identity::DefaultAzureCredential>();
+                _blob_service_client = std::make_shared<BlobServiceClient>(url, credential, options);
+                LOG(DEBUG) << "Azure client initialized with DefaultAzureCredential for account: " << _account_name.value();
+            }
         } else {
 #ifdef AZURITE_TESTING
             LOG(ERROR) << "Azure credentials required. Set AZURE_STORAGE_CONNECTION_STRING or AZURE_STORAGE_ACCOUNT_NAME.";
@@ -125,6 +140,7 @@ bool AzureClient::verify_credentials(const common::backend_api::ObjectClientConf
     // Parse config credentials without creating full client
     ClientConfiguration temp_config;
     std::optional<std::string> temp_account_name = temp_config.account_name;
+    std::optional<std::string> temp_account_key = temp_config.account_key;
 #ifdef AZURITE_TESTING
     std::optional<std::string> temp_connection_string = temp_config.connection_string;
 #endif
@@ -134,6 +150,7 @@ bool AzureClient::verify_credentials(const common::backend_api::ObjectClientConf
     if (ptr) {
         for (size_t i = 0; i < config.num_initial_params; ++i, ++ptr) {
             if (strcmp(ptr->key, "account_name") == 0) temp_account_name = std::string(ptr->value);
+            else if (strcmp(ptr->key, "account_key") == 0) temp_account_key = std::string(ptr->value);
 #ifdef AZURITE_TESTING
             else if (strcmp(ptr->key, "connection_string") == 0) temp_connection_string = std::string(ptr->value);
 #endif
@@ -145,7 +162,7 @@ bool AzureClient::verify_credentials(const common::backend_api::ObjectClientConf
         return (_connection_string == temp_connection_string);
     }
 #endif
-    return (_account_name == temp_account_name);
+    return (_account_name == temp_account_name) && (_account_key == temp_account_key);
 }
 
 common::backend_api::Response AzureClient::async_read_response()

--- a/cpp/azure/client/client.h
+++ b/cpp/azure/client/client.h
@@ -44,8 +44,9 @@ struct AzureClient : common::IClient
     ClientConfiguration _client_config;
     const size_t _chunk_bytesize;
     
-    // Azure credentials (uses DefaultAzureCredential)
+    // Azure credentials
     std::optional<std::string> _account_name;
+    std::optional<std::string> _account_key;
 #ifdef AZURITE_TESTING
     std::optional<std::string> _connection_string;
 #endif

--- a/cpp/azure/client_configuration/client_configuration.cc
+++ b/cpp/azure/client_configuration/client_configuration.cc
@@ -21,6 +21,13 @@ ClientConfiguration::ClientConfiguration()
     }
 #endif
 
+    // Account key for StorageSharedKeyCredential authentication
+    const auto acct_key = utils::getenv<std::string>("AZURE_STORAGE_ACCOUNT_KEY", "");
+    if (!acct_key.empty()) {
+        LOG(DEBUG) << "Using AZURE_STORAGE_ACCOUNT_KEY for authentication";
+        account_key = acct_key;
+    }
+
     // Account name configuration from environment variable
     // Authentication uses DefaultAzureCredential which supports:
     // - Environment variables (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET)

--- a/cpp/azure/client_configuration/client_configuration.h
+++ b/cpp/azure/client_configuration/client_configuration.h
@@ -8,8 +8,9 @@ namespace runai::llm::streamer::impl::azure
 
 struct ClientConfiguration
 {
-    // Azure client configuration options (uses DefaultAzureCredential)
+    // Azure client configuration options
     std::optional<std::string> account_name;
+    std::optional<std::string> account_key;
 #ifdef AZURITE_TESTING
     // Connection string is only available for Azurite/local testing
     std::optional<std::string> connection_string;

--- a/py/runai_model_streamer_azure/runai_model_streamer_azure/credentials/credentials.py
+++ b/py/runai_model_streamer_azure/runai_model_streamer_azure/credentials/credentials.py
@@ -9,28 +9,28 @@ class AzureCredentials:
     """
     Azure Blob Storage credentials configuration.
 
-    Uses DefaultAzureCredential by default, which supports:
-    - Managed Identity
-    - Azure CLI
-    - Environment credentials (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET)
-    - Visual Studio Code credentials
+    Authentication methods (checked in this order):
+    1. Connection string: Set AZURE_STORAGE_CONNECTION_STRING
+    2. Storage account key: Set AZURE_STORAGE_ACCOUNT_NAME and AZURE_STORAGE_ACCOUNT_KEY
+    3. DefaultAzureCredential: Set AZURE_STORAGE_ACCOUNT_NAME (uses Managed Identity, Azure CLI, etc.)
 
-    For local testing, set AZURE_STORAGE_CONNECTION_STRING to use connection string auth.
-    
     If values are not provided explicitly, they are loaded from environment variables:
     - AZURE_STORAGE_CONNECTION_STRING
     - AZURE_STORAGE_ACCOUNT_NAME
+    - AZURE_STORAGE_ACCOUNT_KEY
     """
 
     def __init__(
         self,
         account_name: Optional[str] = None,
+        account_key: Optional[str] = None,
         connection_string: Optional[str] = None,
         credential: Optional[DefaultAzureCredential] = None
     ):
         self.connection_string = connection_string or os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
         self.account_name = account_name or os.environ.get("AZURE_STORAGE_ACCOUNT_NAME")
-        if credential is None and not self.connection_string:
+        self.account_key = account_key or os.environ.get("AZURE_STORAGE_ACCOUNT_KEY")
+        if credential is None and not self.connection_string and not self.account_key:
             credential = DefaultAzureCredential()
         self.credential = credential
         self._validate()

--- a/py/runai_model_streamer_azure/runai_model_streamer_azure/files/files.py
+++ b/py/runai_model_streamer_azure/runai_model_streamer_azure/files/files.py
@@ -20,7 +20,8 @@ def _create_client(credentials: Optional[AzureCredentials] = None) -> BlobServic
 
     Authentication priority:
     1. Connection string (AZURE_STORAGE_CONNECTION_STRING) - for local testing with Azurite
-    2. DefaultAzureCredential with account URL - for production
+    2. Storage account key (AZURE_STORAGE_ACCOUNT_NAME + AZURE_STORAGE_ACCOUNT_KEY)
+    3. DefaultAzureCredential with account URL - for production
 
     Args:
         credentials: Optional AzureCredentials object
@@ -35,6 +36,15 @@ def _create_client(credentials: Optional[AzureCredentials] = None) -> BlobServic
     if credentials.connection_string:
         return BlobServiceClient.from_connection_string(
             credentials.connection_string,
+            user_agent=_USER_AGENT
+        )
+
+    # Use account name + account key if available (StorageSharedKeyCredential)
+    if credentials.account_key and credentials.account_name:
+        account_url = f"https://{credentials.account_name}.blob.core.windows.net"
+        return BlobServiceClient(
+            account_url=account_url,
+            credential=credentials.account_key,
             user_agent=_USER_AGENT
         )
 


### PR DESCRIPTION
## Summary

Add support for authenticating to Azure Blob Storage using a storage account key (`AZURE_STORAGE_ACCOUNT_KEY`) via `StorageSharedKeyCredential`, in addition to the existing `DefaultAzureCredential` flow added in #116.

This is useful for environments where managed identity or Azure CLI auth is not available, but a storage account key is.

## Authentication Priority Order

1. **Connection string** (`AZURE_STORAGE_CONNECTION_STRING`) — Azurite/local testing only (requires `AZURITE_TESTING` build)
2. **Account name + account key** (`AZURE_STORAGE_ACCOUNT_NAME` + `AZURE_STORAGE_ACCOUNT_KEY`) — `StorageSharedKeyCredential`
3. **Account name + DefaultAzureCredential** (`AZURE_STORAGE_ACCOUNT_NAME`) — Managed Identity, Azure CLI, service principal, etc.

## Changes

### C++ Backend
- `client_configuration.h/cc`: Added `account_key` field, reads `AZURE_STORAGE_ACCOUNT_KEY` env var
- `client.h/cc`: Added `_account_key` member, creates `BlobServiceClient` with `StorageSharedKeyCredential` when both account name and key are provided; also accepts `account_key` as an API parameter
- `azure.h`: Updated documentation with new auth method and examples

### Python Package
- `credentials.py`: Added `account_key` parameter to `AzureCredentials`, reads `AZURE_STORAGE_ACCOUNT_KEY` env var
- `files.py`: Creates `BlobServiceClient` with account key credential when available

## Usage

```bash
# Account key authentication
AZURE_STORAGE_ACCOUNT_NAME="myaccount" AZURE_STORAGE_ACCOUNT_KEY="mykey" <streamer app> az://container/path
```

## Depends On

This PR includes changes from #116 (Azure Blob Storage support) and adds account key authentication on top.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Azure Storage account key-based authentication. Users can now authenticate using storage account credentials (`AZURE_STORAGE_ACCOUNT_NAME` + `AZURE_STORAGE_ACCOUNT_KEY`) as an alternative to connection strings and managed identity.
  * Updated authentication selection order: connection strings → account key credentials → managed identity fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->