### PR TITLE
feat: pluggable azure blob cache provider with auto-discovery (experimental)

### DIFF
--- a/cpp/azure/azcache_provider/BUILD
+++ b/cpp/azure/azcache_provider/BUILD
@@ -1,0 +1,35 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_binary")
+load("//:rules.bzl", "runai_cc_test")
+
+cc_library(
+    name = "azcache_provider",
+    srcs = ["azcache_provider_loader.cc"],
+    hdrs = [
+        "runai_azcache_provider.h",
+        "azcache_provider_loader.h",
+    ],
+    visibility = ["//azure:__subpackages__"],
+    deps = [
+        "//utils/logging",
+        "//utils/env",
+    ],
+    linkopts = ["-ldl"],
+)
+
+# Build the test cache provider as a shared library
+cc_binary(
+    name = "libsimple_file_cache_test.so",
+    srcs = ["simple_file_cache_test.cc"],
+    linkshared = True,
+    linkstatic = False,
+)
+
+runai_cc_test(
+    name = "azcache_provider_test",
+    srcs = ["azcache_provider_test.cc"],
+    data = [":libsimple_file_cache_test.so"],
+    deps = [
+        ":azcache_provider",
+    ],
+    linkopts = ["-ldl"],
+)

--- a/cpp/azure/azcache_provider/BUILD
+++ b/cpp/azure/azcache_provider/BUILD
@@ -11,6 +11,7 @@ cc_library(
     visibility = ["//azure:__subpackages__"],
     deps = [
         "//common/exception",
+        "//utils/dylib",
         "//utils/logging",
         "//utils/env",
     ],

--- a/cpp/azure/azcache_provider/BUILD
+++ b/cpp/azure/azcache_provider/BUILD
@@ -10,6 +10,7 @@ cc_library(
     ],
     visibility = ["//azure:__subpackages__"],
     deps = [
+        "//common/exception",
         "//utils/logging",
         "//utils/env",
     ],

--- a/cpp/azure/azcache_provider/BUILD
+++ b/cpp/azure/azcache_provider/BUILD
@@ -1,0 +1,35 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_binary")
+load("//:rules.bzl", "runai_cc_test")
+
+cc_library(
+    name = "azcache_provider",
+    srcs = ["azcache_provider_loader.cc"],
+    hdrs = [
+        "runai_azcache_provider.h",
+        "azcache_provider_loader.h",
+    ],
+    visibility = ["//azure:__subpackages__"],
+    deps = [
+        "//utils/logging",
+        "//utils/env",
+    ],
+    linkopts = ["-ldl"],
+)
+
+# Build the example cache as a shared library for testing
+cc_binary(
+    name = "libsimple_file_cache.so",
+    srcs = ["simple_file_cache.cc"],
+    linkshared = True,
+    linkstatic = False,
+)
+
+runai_cc_test(
+    name = "azcache_provider_test",
+    srcs = ["azcache_provider_test.cc"],
+    data = [":libsimple_file_cache.so"],
+    deps = [
+        ":azcache_provider",
+    ],
+    linkopts = ["-ldl"],
+)

--- a/cpp/azure/azcache_provider/azcache_provider_loader.cc
+++ b/cpp/azure/azcache_provider/azcache_provider_loader.cc
@@ -1,0 +1,188 @@
+#include "azure/azcache_provider/azcache_provider_loader.h"
+
+#include <cstdlib>
+#include <dlfcn.h>
+#include <filesystem>
+#include <algorithm>
+
+#include "utils/logging/logging.h"
+#include "utils/env/env.h"
+
+namespace runai::llm::streamer::impl::azure
+{
+
+namespace
+{
+
+// Known cache provider package/library names for auto-discovery
+constexpr const char* CACHE_PROVIDER_PACKAGE = "py_tachyon_client";
+constexpr const char* CACHE_PROVIDER_LIB = "libStorageDirect.so";
+
+/**
+ * Use dladdr on a symbol known to live in libstreamerazure.so to locate
+ * the site-packages directory, then look for a known cache provider .so.
+ *
+ * Layout: <site-packages>/runai_model_streamer/libstreamer/lib/libstreamerazure.so
+ *         <site-packages>/<CACHE_PROVIDER_PACKAGE>/<CACHE_PROVIDER_LIB>
+ */
+std::string autodiscover_cache_lib()
+{
+    // Use dladdr on a function in this translation unit to find where
+    // libstreamerazure.so is loaded from
+    Dl_info info;
+    auto fn_ptr = reinterpret_cast<void*>(&autodiscover_cache_lib);
+    if (!dladdr(fn_ptr, &info) || !info.dli_fname)
+    {
+        LOG(DEBUG) << "AzCacheProvider: dladdr failed — cannot auto-discover";
+        return {};
+    }
+
+    std::error_code ec;
+    auto azure_so = std::filesystem::weakly_canonical(info.dli_fname, ec);
+    if (ec)
+    {
+        LOG(DEBUG) << "AzCacheProvider: canonical path failed for " << info.dli_fname;
+        return {};
+    }
+
+    // libstreamerazure.so → lib/ → libstreamer/ → runai_model_streamer/ → site-packages/
+    auto site_packages = azure_so.parent_path().parent_path().parent_path().parent_path();
+    auto candidate = site_packages / CACHE_PROVIDER_PACKAGE / CACHE_PROVIDER_LIB;
+
+    if (std::filesystem::exists(candidate, ec) && !ec)
+    {
+        return candidate.string();
+    }
+
+    LOG(DEBUG) << "AzCacheProvider: auto-discovery checked " << candidate.string() << " — not found";
+    return {};
+}
+
+bool is_disabled_value(const std::string& val)
+{
+    std::string lower = val;
+    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+    return lower == "0" || lower == "false" || lower == "disabled" || lower == "none" || lower == "no";
+}
+
+} // anonymous namespace
+
+AzCacheProviderLoader& AzCacheProviderLoader::instance()
+{
+    static AzCacheProviderLoader instance;
+    return instance;
+}
+
+AzCacheProviderLoader::AzCacheProviderLoader()
+    : _lib_handle(nullptr),
+      _cache_read(nullptr),
+      _enabled(false)
+{
+    // Master kill switch — check RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_ENABLED first
+    std::string enabled_val;
+    if (utils::try_getenv<std::string>(RUNAI_AZURE_CACHE_ENABLED_ENV, enabled_val))
+    {
+        if (is_disabled_value(enabled_val))
+        {
+            LOG(INFO) << "AzCacheProvider: disabled via " << RUNAI_AZURE_CACHE_ENABLED_ENV << "=" << enabled_val;
+            return;
+        }
+    }
+
+    // Determine library path: explicit override or auto-discovery
+    std::string lib_path;
+    if (utils::try_getenv<std::string>(RUNAI_AZURE_CACHE_LIB_ENV, lib_path))
+    {
+        if (is_disabled_value(lib_path))
+        {
+            LOG(INFO) << "AzCacheProvider: explicitly disabled via " << RUNAI_AZURE_CACHE_LIB_ENV << "=" << lib_path;
+            return;
+        }
+    }
+    else
+    {
+        // Env var not set — try auto-discovery
+        lib_path = autodiscover_cache_lib();
+        if (lib_path.empty())
+        {
+            LOG(DEBUG) << "AzCacheProvider: no cache provider found — cache disabled";
+            return;
+        }
+        LOG(INFO) << "AzCacheProvider: auto-discovered cache library: " << lib_path;
+    }
+
+    _lib_path = lib_path;
+    LOG(INFO) << "AzCacheProvider: loading cache library: " << _lib_path;
+
+    _lib_handle = dlopen(_lib_path.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (!_lib_handle)
+    {
+        LOG(WARNING) << "AzCacheProvider: dlopen failed for '" << _lib_path << "': " << dlerror();
+        return;
+    }
+
+    _cache_read = reinterpret_cast<blob_read_fn>(
+        dlsym(_lib_handle, BLOB_READ_SYMBOL));
+    if (!_cache_read)
+    {
+        LOG(WARNING) << "AzCacheProvider: dlsym failed for '" << BLOB_READ_SYMBOL
+                     << "': " << dlerror();
+        dlclose(_lib_handle);
+        _lib_handle = nullptr;
+        return;
+    }
+
+    _enabled = true;
+    LOG(INFO) << "AzCacheProvider: cache provider loaded successfully from " << _lib_path;
+}
+
+AzCacheProviderLoader::~AzCacheProviderLoader()
+{
+    // Intentionally do NOT dlclose — at static destruction time the loaded
+    // library may have already torn down its own statics, leading to
+    // use-after-free.  The OS reclaims everything on process exit.
+}
+
+bool AzCacheProviderLoader::read(
+    const std::string& account,
+    const std::string& container,
+    const std::string& blob,
+    char* buffer,
+    size_t offset,
+    size_t length)
+{
+    if (!_enabled)
+    {
+        return false;
+    }
+
+    char* error_string = nullptr;
+    ssize_t bytes_read = _cache_read(
+        account.c_str(), container.c_str(), blob.c_str(),
+        buffer, offset, length, &error_string);
+
+    if (bytes_read < 0 || static_cast<size_t>(bytes_read) != length)
+    {
+        if (error_string)
+        {
+            LOG(ERROR) << "AzCacheProvider: cache read failed for "
+                       << account << "/" << container << "/" << blob
+                       << " offset=" << offset << " length=" << length
+                       << ": " << error_string;
+            free(error_string);
+        }
+        else
+        {
+            LOG(ERROR) << "AzCacheProvider: cache read failed for "
+                       << account << "/" << container << "/" << blob
+                       << " offset=" << offset << " length=" << length;
+        }
+        return false;
+    }
+
+    LOG(SPAM) << "AzCacheProvider: cache read " << length << " bytes from "
+              << account << "/" << container << "/" << blob << " offset=" << offset;
+    return true;
+}
+
+} // namespace runai::llm::streamer::impl::azure

--- a/cpp/azure/azcache_provider/azcache_provider_loader.cc
+++ b/cpp/azure/azcache_provider/azcache_provider_loader.cc
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <algorithm>
 
+#include "common/exception/exception.h"
 #include "utils/logging/logging.h"
 #include "utils/env/env.h"
 
@@ -27,8 +28,6 @@ constexpr const char* CACHE_PROVIDER_LIB = "libStorageDirect.so";
  */
 std::string autodiscover_cache_lib()
 {
-    // Use dladdr on a function in this translation unit to find where
-    // libstreamerazure.so is loaded from
     Dl_info info;
     auto fn_ptr = reinterpret_cast<void*>(&autodiscover_cache_lib);
     if (!dladdr(fn_ptr, &info) || !info.dli_fname)
@@ -41,7 +40,8 @@ std::string autodiscover_cache_lib()
     auto azure_so = std::filesystem::weakly_canonical(info.dli_fname, ec);
     if (ec)
     {
-        LOG(DEBUG) << "AzCacheProvider: canonical path failed for " << info.dli_fname;
+        LOG(DEBUG) << "AzCacheProvider: canonical path failed for "
+                   << info.dli_fname << ": " << ec.message();
         return {};
     }
 
@@ -54,70 +54,111 @@ std::string autodiscover_cache_lib()
         return candidate.string();
     }
 
-    LOG(DEBUG) << "AzCacheProvider: auto-discovery checked " << candidate.string() << " — not found";
+    LOG(DEBUG) << "AzCacheProvider: auto-discovery checked " << candidate.string()
+               << " — not found" << (ec ? ": " + ec.message() : "");
     return {};
 }
 
-bool is_disabled_value(const std::string& val)
+CacheMode parse_cache_mode(const std::string& val)
 {
     std::string lower = val;
-    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
-    return lower == "0" || lower == "false" || lower == "disabled" || lower == "none" || lower == "no";
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+        [](unsigned char c) { return std::tolower(c); });
+
+    if (lower == "0")
+    {
+        return CacheMode::Disabled;
+    }
+    if (lower == "1")
+    {
+        return CacheMode::Required;
+    }
+    // "auto" or any other value → auto mode
+    return CacheMode::Auto;
 }
 
 } // anonymous namespace
 
-AzCacheProviderLoader& AzCacheProviderLoader::instance()
+std::shared_ptr<AzCacheProviderLoader> AzCacheProviderLoader::from_env()
 {
-    static AzCacheProviderLoader instance;
-    return instance;
+    CacheProviderConfig config;
+    config.mode = CacheMode::Auto;
+
+    // Parse mode from RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_ENABLED
+    std::string enabled_val;
+    if (utils::try_getenv<std::string>(RUNAI_AZURE_CACHE_ENABLED_ENV, enabled_val))
+    {
+        config.mode = parse_cache_mode(enabled_val);
+        if (config.mode == CacheMode::Disabled)
+        {
+            LOG(INFO) << "AzCacheProvider: disabled via " << RUNAI_AZURE_CACHE_ENABLED_ENV << "=" << enabled_val;
+        }
+    }
+
+    // Parse explicit library path from RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_LIB
+    std::string lib_path;
+    if (utils::try_getenv<std::string>(RUNAI_AZURE_CACHE_LIB_ENV, lib_path))
+    {
+        if (lib_path.empty())
+        {
+            LOG(WARNING) << "AzCacheProvider: " << RUNAI_AZURE_CACHE_LIB_ENV
+                         << " is set to empty string — ignoring";
+        }
+        else
+        {
+            config.lib_path = lib_path;
+        }
+    }
+
+    // Auto-discover if no explicit path and not disabled
+    if (config.lib_path.empty() && config.mode != CacheMode::Disabled)
+    {
+        std::string discovered = autodiscover_cache_lib();
+        if (!discovered.empty())
+        {
+            LOG(INFO) << "AzCacheProvider: auto-discovered cache library: " << discovered;
+            config.lib_path = discovered;
+        }
+    }
+
+    return std::make_shared<AzCacheProviderLoader>(config);
 }
 
-AzCacheProviderLoader::AzCacheProviderLoader()
+AzCacheProviderLoader::AzCacheProviderLoader(const CacheProviderConfig& config)
     : _lib_handle(nullptr),
       _cache_read(nullptr),
       _enabled(false)
 {
-    // Master kill switch — check RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_ENABLED first
-    std::string enabled_val;
-    if (utils::try_getenv<std::string>(RUNAI_AZURE_CACHE_ENABLED_ENV, enabled_val))
+    if (config.mode == CacheMode::Disabled)
     {
-        if (is_disabled_value(enabled_val))
-        {
-            LOG(INFO) << "AzCacheProvider: disabled via " << RUNAI_AZURE_CACHE_ENABLED_ENV << "=" << enabled_val;
-            return;
-        }
+        return;
     }
 
-    // Determine library path: explicit override or auto-discovery
-    std::string lib_path;
-    if (utils::try_getenv<std::string>(RUNAI_AZURE_CACHE_LIB_ENV, lib_path))
+    if (config.lib_path.empty())
     {
-        if (is_disabled_value(lib_path))
+        if (config.mode == CacheMode::Required)
         {
-            LOG(INFO) << "AzCacheProvider: explicitly disabled via " << RUNAI_AZURE_CACHE_LIB_ENV << "=" << lib_path;
-            return;
+            LOG(ERROR) << "AzCacheProvider: mode=1 (required) but no cache library path configured. "
+                       << "Set " << RUNAI_AZURE_CACHE_LIB_ENV << " or install a cache provider package.";
+            throw common::Exception(common::ResponseCode::InvalidParameterError);
         }
-    }
-    else
-    {
-        // Env var not set — try auto-discovery
-        lib_path = autodiscover_cache_lib();
-        if (lib_path.empty())
-        {
-            LOG(DEBUG) << "AzCacheProvider: no cache provider found — cache disabled";
-            return;
-        }
-        LOG(INFO) << "AzCacheProvider: auto-discovered cache library: " << lib_path;
+        LOG(DEBUG) << "AzCacheProvider: no cache library configured — cache disabled";
+        return;
     }
 
-    _lib_path = lib_path;
+    _lib_path = config.lib_path;
     LOG(INFO) << "AzCacheProvider: loading cache library: " << _lib_path;
 
     _lib_handle = dlopen(_lib_path.c_str(), RTLD_NOW | RTLD_LOCAL);
     if (!_lib_handle)
     {
-        LOG(WARNING) << "AzCacheProvider: dlopen failed for '" << _lib_path << "': " << dlerror();
+        std::string err = dlerror();
+        if (config.mode == CacheMode::Required)
+        {
+            LOG(ERROR) << "AzCacheProvider: dlopen failed for '" << _lib_path << "': " << err;
+            throw common::Exception(common::ResponseCode::InvalidParameterError);
+        }
+        LOG(WARNING) << "AzCacheProvider: dlopen failed for '" << _lib_path << "': " << err;
         return;
     }
 
@@ -125,8 +166,15 @@ AzCacheProviderLoader::AzCacheProviderLoader()
         dlsym(_lib_handle, BLOB_READ_SYMBOL));
     if (!_cache_read)
     {
-        LOG(WARNING) << "AzCacheProvider: dlsym failed for '" << BLOB_READ_SYMBOL
-                     << "': " << dlerror();
+        std::string err = dlerror();
+        if (config.mode == CacheMode::Required)
+        {
+            LOG(ERROR) << "AzCacheProvider: dlsym failed for '" << BLOB_READ_SYMBOL << "': " << err;
+            dlclose(_lib_handle);
+            _lib_handle = nullptr;
+            throw common::Exception(common::ResponseCode::InvalidParameterError);
+        }
+        LOG(WARNING) << "AzCacheProvider: dlsym failed for '" << BLOB_READ_SYMBOL << "': " << err;
         dlclose(_lib_handle);
         _lib_handle = nullptr;
         return;
@@ -138,7 +186,7 @@ AzCacheProviderLoader::AzCacheProviderLoader()
 
 AzCacheProviderLoader::~AzCacheProviderLoader()
 {
-    // Intentionally do NOT dlclose — at static destruction time the loaded
+    // Intentionally do NOT dlclose — at destruction time the loaded
     // library may have already torn down its own statics, leading to
     // use-after-free.  The OS reclaims everything on process exit.
 }
@@ -156,20 +204,19 @@ bool AzCacheProviderLoader::read(
         return false;
     }
 
-    char* error_string = nullptr;
+    char error_buf[RUNAI_CACHE_ERROR_BUF_SIZE] = {};
     ssize_t bytes_read = _cache_read(
         account.c_str(), container.c_str(), blob.c_str(),
-        buffer, offset, length, &error_string);
+        buffer, offset, length, error_buf, sizeof(error_buf));
 
     if (bytes_read < 0 || static_cast<size_t>(bytes_read) != length)
     {
-        if (error_string)
+        if (error_buf[0] != '\0')
         {
             LOG(ERROR) << "AzCacheProvider: cache read failed for "
                        << account << "/" << container << "/" << blob
                        << " offset=" << offset << " length=" << length
-                       << ": " << error_string;
-            free(error_string);
+                       << ": " << error_buf;
         }
         else
         {

--- a/cpp/azure/azcache_provider/azcache_provider_loader.cc
+++ b/cpp/azure/azcache_provider/azcache_provider_loader.cc
@@ -6,11 +6,16 @@
 #include <algorithm>
 
 #include "common/exception/exception.h"
+#include "utils/dylib/dylib.h"
 #include "utils/logging/logging.h"
 #include "utils/env/env.h"
 
 namespace runai::llm::streamer::impl::azure
 {
+
+// Static members
+std::weak_ptr<CacheLibHandle> AzCacheProviderLoader::s_shared_handle;
+std::mutex AzCacheProviderLoader::s_handle_mutex;
 
 namespace
 {
@@ -79,6 +84,131 @@ CacheMode parse_cache_mode(const std::string& val)
 
 } // anonymous namespace
 
+// --- CacheLibHandle implementation ---
+
+CacheLibHandle::CacheLibHandle(const std::string& path, CacheMode mode)
+    : lib_handle(nullptr),
+      read_fn(nullptr),
+      close_fn(nullptr),
+      lib_path(path)
+{
+    LOG(INFO) << "AzCacheProvider: loading cache library: " << lib_path;
+
+    try
+    {
+        lib_handle = utils::Dylib::dlopen(lib_path, RTLD_NOW | RTLD_LOCAL);
+    }
+    catch (...)
+    {
+        if (mode == CacheMode::Required)
+        {
+            throw common::Exception(common::ResponseCode::InvalidParameterError);
+        }
+        return;
+    }
+
+    // ABI version check
+    runai_cache_abi_version_fn version_fn = nullptr;
+    try
+    {
+        version_fn = utils::Dylib::dlsym<runai_cache_abi_version_fn>(lib_handle, RUNAI_CACHE_ABI_VERSION_SYMBOL);
+    }
+    catch (...)
+    {
+        if (mode == CacheMode::Required)
+        {
+            LOG(ERROR) << "AzCacheProvider: '" << lib_path << "' does not export "
+                       << RUNAI_CACHE_ABI_VERSION_SYMBOL << " — incompatible library";
+            utils::Dylib::dlclose(lib_handle);
+            lib_handle = nullptr;
+            throw common::Exception(common::ResponseCode::InvalidParameterError);
+        }
+        LOG(WARNING) << "AzCacheProvider: '" << lib_path << "' does not export "
+                     << RUNAI_CACHE_ABI_VERSION_SYMBOL << " — skipping (pre-versioning build)";
+        utils::Dylib::dlclose(lib_handle);
+        lib_handle = nullptr;
+        return;
+    }
+
+    uint32_t lib_version = version_fn();
+    if (lib_version != RUNAI_CACHE_ABI_VERSION)
+    {
+        if (mode == CacheMode::Required)
+        {
+            LOG(ERROR) << "AzCacheProvider: ABI version mismatch — expected "
+                       << RUNAI_CACHE_ABI_VERSION << ", got " << lib_version;
+            utils::Dylib::dlclose(lib_handle);
+            lib_handle = nullptr;
+            throw common::Exception(common::ResponseCode::InvalidParameterError);
+        }
+        LOG(WARNING) << "AzCacheProvider: ABI version mismatch — expected "
+                     << RUNAI_CACHE_ABI_VERSION << ", got " << lib_version << " — skipping";
+        utils::Dylib::dlclose(lib_handle);
+        lib_handle = nullptr;
+        return;
+    }
+
+    // Resolve blob_read (required)
+    try
+    {
+        read_fn = utils::Dylib::dlsym<blob_read_fn>(lib_handle, BLOB_READ_SYMBOL);
+    }
+    catch (...)
+    {
+        if (mode == CacheMode::Required)
+        {
+            utils::Dylib::dlclose(lib_handle);
+            lib_handle = nullptr;
+            throw common::Exception(common::ResponseCode::InvalidParameterError);
+        }
+        utils::Dylib::dlclose(lib_handle);
+        lib_handle = nullptr;
+        return;
+    }
+
+    // Resolve shutdown (optional — don't throw if missing)
+    try
+    {
+        close_fn = utils::Dylib::dlsym<shutdown_fn>(lib_handle, SHUTDOWN_SYMBOL);
+    }
+    catch (...)
+    {
+        close_fn = nullptr; // not exported, that's fine
+    }
+
+    LOG(INFO) << "AzCacheProvider: cache provider loaded successfully from " << lib_path
+              << " (shutdown: " << (close_fn ? "yes" : "no") << ")";
+}
+
+CacheLibHandle::~CacheLibHandle()
+{
+    if (!lib_handle)
+    {
+        return;
+    }
+
+    // Call shutdown() for graceful shutdown before releasing the handle
+    if (close_fn)
+    {
+        LOG(INFO) << "AzCacheProvider: calling shutdown() for graceful shutdown";
+        try
+        {
+            close_fn();
+        }
+        catch (...)
+        {
+            LOG(ERROR) << "AzCacheProvider: shutdown() threw an exception";
+        }
+    }
+
+    // Note: we intentionally do NOT call dlclose() here.
+    lib_handle = nullptr;
+
+    LOG(DEBUG) << "AzCacheProvider: released cache provider handle";
+}
+
+// --- AzCacheProviderLoader implementation ---
+
 std::shared_ptr<AzCacheProviderLoader> AzCacheProviderLoader::from_env()
 {
     CacheProviderConfig config;
@@ -125,8 +255,7 @@ std::shared_ptr<AzCacheProviderLoader> AzCacheProviderLoader::from_env()
 }
 
 AzCacheProviderLoader::AzCacheProviderLoader(const CacheProviderConfig& config)
-    : _lib_handle(nullptr),
-      _cache_read(nullptr),
+    : _handle(nullptr),
       _enabled(false)
 {
     if (config.mode == CacheMode::Disabled)
@@ -146,86 +275,36 @@ AzCacheProviderLoader::AzCacheProviderLoader(const CacheProviderConfig& config)
         return;
     }
 
-    _lib_path = config.lib_path;
-    LOG(INFO) << "AzCacheProvider: loading cache library: " << _lib_path;
-
-    _lib_handle = dlopen(_lib_path.c_str(), RTLD_NOW | RTLD_LOCAL);
-    if (!_lib_handle)
+    // Acquire or create the shared library handle
     {
-        std::string err = dlerror();
-        if (config.mode == CacheMode::Required)
+        std::lock_guard<std::mutex> lock(s_handle_mutex);
+        _handle = s_shared_handle.lock();
+
+        if (_handle && _handle->lib_handle && _handle->lib_path == config.lib_path)
         {
-            LOG(ERROR) << "AzCacheProvider: dlopen failed for '" << _lib_path << "': " << err;
-            throw common::Exception(common::ResponseCode::InvalidParameterError);
+            // Reuse existing handle for same library
+            LOG(DEBUG) << "AzCacheProvider: reusing shared cache library handle for " << config.lib_path;
         }
-        LOG(WARNING) << "AzCacheProvider: dlopen failed for '" << _lib_path << "': " << err;
-        return;
+        else
+        {
+            // Create new handle (first loader or path changed)
+            _handle = std::make_shared<CacheLibHandle>(config.lib_path, config.mode);
+            s_shared_handle = _handle;
+        }
     }
 
-    // ABI version check — reject incompatible libraries early
-    auto version_fn = reinterpret_cast<runai_cache_abi_version_fn>(
-        dlsym(_lib_handle, RUNAI_CACHE_ABI_VERSION_SYMBOL));
-    if (!version_fn)
+    if (_handle && _handle->read_fn)
     {
-        if (config.mode == CacheMode::Required)
-        {
-            LOG(ERROR) << "AzCacheProvider: '" << _lib_path << "' does not export "
-                       << RUNAI_CACHE_ABI_VERSION_SYMBOL << " — incompatible library";
-            dlclose(_lib_handle);
-            _lib_handle = nullptr;
-            throw common::Exception(common::ResponseCode::InvalidParameterError);
-        }
-        LOG(WARNING) << "AzCacheProvider: '" << _lib_path << "' does not export "
-                     << RUNAI_CACHE_ABI_VERSION_SYMBOL << " — skipping (pre-versioning build)";
-        dlclose(_lib_handle);
-        _lib_handle = nullptr;
-        return;
+        _enabled = true;
     }
-    uint32_t lib_version = version_fn();
-    if (lib_version != RUNAI_CACHE_ABI_VERSION)
-    {
-        if (config.mode == CacheMode::Required)
-        {
-            LOG(ERROR) << "AzCacheProvider: ABI version mismatch — expected "
-                       << RUNAI_CACHE_ABI_VERSION << ", got " << lib_version;
-            dlclose(_lib_handle);
-            _lib_handle = nullptr;
-            throw common::Exception(common::ResponseCode::InvalidParameterError);
-        }
-        LOG(WARNING) << "AzCacheProvider: ABI version mismatch — expected "
-                     << RUNAI_CACHE_ABI_VERSION << ", got " << lib_version << " — skipping";
-        dlclose(_lib_handle);
-        _lib_handle = nullptr;
-        return;
-    }
-
-    _cache_read = reinterpret_cast<blob_read_fn>(
-        dlsym(_lib_handle, BLOB_READ_SYMBOL));
-    if (!_cache_read)
-    {
-        std::string err = dlerror();
-        if (config.mode == CacheMode::Required)
-        {
-            LOG(ERROR) << "AzCacheProvider: dlsym failed for '" << BLOB_READ_SYMBOL << "': " << err;
-            dlclose(_lib_handle);
-            _lib_handle = nullptr;
-            throw common::Exception(common::ResponseCode::InvalidParameterError);
-        }
-        LOG(WARNING) << "AzCacheProvider: dlsym failed for '" << BLOB_READ_SYMBOL << "': " << err;
-        dlclose(_lib_handle);
-        _lib_handle = nullptr;
-        return;
-    }
-
-    _enabled = true;
-    LOG(INFO) << "AzCacheProvider: cache provider loaded successfully from " << _lib_path;
 }
 
 AzCacheProviderLoader::~AzCacheProviderLoader()
 {
-    // Intentionally do NOT dlclose — at destruction time the loaded
-    // library may have already torn down its own statics, leading to
-    // use-after-free.  The OS reclaims everything on process exit.
+    // Release under mutex so destruction of CacheLibHandle (which calls shutdown())
+    // cannot race with a new loader trying to lock() the weak_ptr and recreate.
+    std::lock_guard<std::mutex> lock(s_handle_mutex);
+    _handle.reset();
 }
 
 bool AzCacheProviderLoader::read(
@@ -236,13 +315,13 @@ bool AzCacheProviderLoader::read(
     size_t offset,
     size_t length)
 {
-    if (!_enabled)
+    if (!_enabled || !_handle || !_handle->read_fn)
     {
         return false;
     }
 
     char error_buf[RUNAI_CACHE_ERROR_BUF_SIZE] = {};
-    ssize_t bytes_read = _cache_read(
+    ssize_t bytes_read = _handle->read_fn(
         account.c_str(), container.c_str(), blob.c_str(),
         buffer, offset, length, error_buf, sizeof(error_buf));
 

--- a/cpp/azure/azcache_provider/azcache_provider_loader.cc
+++ b/cpp/azure/azcache_provider/azcache_provider_loader.cc
@@ -1,0 +1,103 @@
+#include "azure/azcache_provider/azcache_provider_loader.h"
+
+#include <cstdlib>
+#include <dlfcn.h>
+
+#include "utils/logging/logging.h"
+#include "utils/env/env.h"
+
+namespace runai::llm::streamer::impl::azure
+{
+
+AzCacheProviderLoader& AzCacheProviderLoader::instance()
+{
+    static AzCacheProviderLoader instance;
+    return instance;
+}
+
+AzCacheProviderLoader::AzCacheProviderLoader()
+    : _lib_handle(nullptr),
+      _cache_read(nullptr),
+      _enabled(false)
+{
+    std::string lib_path;
+    if (!utils::try_getenv<std::string>(RUNAI_AZURE_CACHE_LIB_ENV, lib_path))
+    {
+        LOG(DEBUG) << "AzCacheProvider: " << RUNAI_AZURE_CACHE_LIB_ENV << " not set — cache disabled";
+        return;
+    }
+
+    _lib_path = lib_path;
+    LOG(INFO) << "AzCacheProvider: loading cache library: " << _lib_path;
+
+    _lib_handle = dlopen(_lib_path.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (!_lib_handle)
+    {
+        LOG(WARNING) << "AzCacheProvider: dlopen failed for '" << _lib_path << "': " << dlerror();
+        return;
+    }
+
+    _cache_read = reinterpret_cast<runai_cache_read_fn>(
+        dlsym(_lib_handle, RUNAI_CACHE_READ_SYMBOL));
+    if (!_cache_read)
+    {
+        LOG(WARNING) << "AzCacheProvider: dlsym failed for '" << RUNAI_CACHE_READ_SYMBOL
+                     << "': " << dlerror();
+        dlclose(_lib_handle);
+        _lib_handle = nullptr;
+        return;
+    }
+
+    _enabled = true;
+    LOG(INFO) << "AzCacheProvider: cache provider loaded successfully from " << _lib_path;
+}
+
+AzCacheProviderLoader::~AzCacheProviderLoader()
+{
+    // Intentionally do NOT dlclose — at static destruction time the loaded
+    // library may have already torn down its own statics, leading to
+    // use-after-free.  The OS reclaims everything on process exit.
+}
+
+bool AzCacheProviderLoader::read(
+    const std::string& container,
+    const std::string& blob,
+    char* buffer,
+    size_t offset,
+    size_t length)
+{
+    if (!_enabled)
+    {
+        return false;
+    }
+
+    char* error_string = nullptr;
+    ssize_t bytes_read = _cache_read(
+        container.c_str(), blob.c_str(),
+        buffer, offset, length, &error_string);
+
+    if (bytes_read < 0 || static_cast<size_t>(bytes_read) != length)
+    {
+        if (error_string)
+        {
+            LOG(ERROR) << "AzCacheProvider: cache read failed for "
+                       << container << "/" << blob
+                       << " offset=" << offset << " length=" << length
+                       << ": " << error_string;
+            free(error_string);
+        }
+        else
+        {
+            LOG(ERROR) << "AzCacheProvider: cache read failed for "
+                       << container << "/" << blob
+                       << " offset=" << offset << " length=" << length;
+        }
+        return false;
+    }
+
+    LOG(SPAM) << "AzCacheProvider: cache read " << length << " bytes from "
+              << container << "/" << blob << " offset=" << offset;
+    return true;
+}
+
+} // namespace runai::llm::streamer::impl::azure

--- a/cpp/azure/azcache_provider/azcache_provider_loader.cc
+++ b/cpp/azure/azcache_provider/azcache_provider_loader.cc
@@ -162,6 +162,43 @@ AzCacheProviderLoader::AzCacheProviderLoader(const CacheProviderConfig& config)
         return;
     }
 
+    // ABI version check — reject incompatible libraries early
+    auto version_fn = reinterpret_cast<runai_cache_abi_version_fn>(
+        dlsym(_lib_handle, RUNAI_CACHE_ABI_VERSION_SYMBOL));
+    if (!version_fn)
+    {
+        if (config.mode == CacheMode::Required)
+        {
+            LOG(ERROR) << "AzCacheProvider: '" << _lib_path << "' does not export "
+                       << RUNAI_CACHE_ABI_VERSION_SYMBOL << " — incompatible library";
+            dlclose(_lib_handle);
+            _lib_handle = nullptr;
+            throw common::Exception(common::ResponseCode::InvalidParameterError);
+        }
+        LOG(WARNING) << "AzCacheProvider: '" << _lib_path << "' does not export "
+                     << RUNAI_CACHE_ABI_VERSION_SYMBOL << " — skipping (pre-versioning build)";
+        dlclose(_lib_handle);
+        _lib_handle = nullptr;
+        return;
+    }
+    uint32_t lib_version = version_fn();
+    if (lib_version != RUNAI_CACHE_ABI_VERSION)
+    {
+        if (config.mode == CacheMode::Required)
+        {
+            LOG(ERROR) << "AzCacheProvider: ABI version mismatch — expected "
+                       << RUNAI_CACHE_ABI_VERSION << ", got " << lib_version;
+            dlclose(_lib_handle);
+            _lib_handle = nullptr;
+            throw common::Exception(common::ResponseCode::InvalidParameterError);
+        }
+        LOG(WARNING) << "AzCacheProvider: ABI version mismatch — expected "
+                     << RUNAI_CACHE_ABI_VERSION << ", got " << lib_version << " — skipping";
+        dlclose(_lib_handle);
+        _lib_handle = nullptr;
+        return;
+    }
+
     _cache_read = reinterpret_cast<blob_read_fn>(
         dlsym(_lib_handle, BLOB_READ_SYMBOL));
     if (!_cache_read)

--- a/cpp/azure/azcache_provider/azcache_provider_loader.h
+++ b/cpp/azure/azcache_provider/azcache_provider_loader.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <atomic>
+#include <mutex>
+#include <string>
+
+#include "azure/azcache_provider/runai_azcache_provider.h"
+
+namespace runai::llm::streamer::impl::azure
+{
+
+/**
+ * AzCacheProviderLoader dynamically loads a cache provider .so at runtime
+ * via dlopen/dlsym.
+ *
+ * Auto-discovers the cache library in Python site-packages (e.g., tachyon_client).
+ * Can be disabled with RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_ENABLED=false.
+ * Can be overridden with RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_LIB=/path/to.so.
+ *
+ * Thread-safe singleton — initialization happens once on first access.
+ */
+class AzCacheProviderLoader
+{
+public:
+    static AzCacheProviderLoader& instance();
+
+    bool is_enabled() const { return _enabled.load(std::memory_order_relaxed); }
+
+    /**
+     * Read blob data through the cache provider.
+     *
+     * @param account    Azure Storage account name
+     * @param container  Azure container name
+     * @param blob       Blob path within the container
+     * @param buffer     Destination buffer (caller-allocated)
+     * @param offset     Byte offset within the blob
+     * @param length     Number of bytes to read
+     * @return true on success, false on error
+     */
+    bool read(const std::string& account,
+              const std::string& container,
+              const std::string& blob,
+              char* buffer,
+              size_t offset,
+              size_t length);
+
+    AzCacheProviderLoader(const AzCacheProviderLoader&) = delete;
+    AzCacheProviderLoader& operator=(const AzCacheProviderLoader&) = delete;
+
+private:
+    AzCacheProviderLoader();
+    ~AzCacheProviderLoader();
+
+    void* _lib_handle;
+    blob_read_fn _cache_read;
+    std::atomic<bool> _enabled;
+    std::string _lib_path;
+};
+
+} // namespace runai::llm::streamer::impl::azure

--- a/cpp/azure/azcache_provider/azcache_provider_loader.h
+++ b/cpp/azure/azcache_provider/azcache_provider_loader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <string>
 
 #include "azure/azcache_provider/runai_azcache_provider.h"
@@ -28,10 +29,33 @@ struct CacheProviderConfig
 };
 
 /**
+ * Shared handle to the dlopen'd cache provider library.
+ * Loaded once, shared across all AzureClient instances via weak_ptr.
+ * When the last strong reference is released, calls shutdown() (if exported)
+ * to gracefully shut down the provider's resources.
+ */
+struct CacheLibHandle
+{
+    CacheLibHandle(const std::string& path, CacheMode mode);
+    ~CacheLibHandle();
+
+    CacheLibHandle(const CacheLibHandle&) = delete;
+    CacheLibHandle& operator=(const CacheLibHandle&) = delete;
+
+    void* lib_handle;
+    blob_read_fn read_fn;
+    shutdown_fn close_fn;  // may be nullptr if not exported
+    std::string lib_path;
+};
+
+/**
  * AzCacheProviderLoader dynamically loads a cache provider .so at runtime
  * via dlopen/dlsym.
  *
- * No longer a global singleton — owned by AzureClient for testability.
+ * The library handle is shared across all loaders via a process-wide weak_ptr.
+ * The first loader to create the handle loads the library; when the last loader
+ * is destroyed, the handle destructor calls shutdown() for graceful shutdown.
+ *
  * Use from_env() to create from environment variables.
  *
  * Thread-safe once constructed (immutable state after construction).
@@ -78,10 +102,11 @@ public:
     AzCacheProviderLoader& operator=(const AzCacheProviderLoader&) = delete;
 
 private:
-    void* _lib_handle;
-    blob_read_fn _cache_read;
+    std::shared_ptr<CacheLibHandle> _handle;
     bool _enabled;
-    std::string _lib_path;
+
+    static std::weak_ptr<CacheLibHandle> s_shared_handle;
+    static std::mutex s_handle_mutex;
 };
 
 } // namespace runai::llm::streamer::impl::azure

--- a/cpp/azure/azcache_provider/azcache_provider_loader.h
+++ b/cpp/azure/azcache_provider/azcache_provider_loader.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <atomic>
+#include <mutex>
+#include <string>
+
+#include "azure/azcache_provider/runai_azcache_provider.h"
+
+namespace runai::llm::streamer::impl::azure
+{
+
+/**
+ * AzCacheProviderLoader dynamically loads a user-supplied cache provider .so
+ * at runtime via dlopen/dlsym.
+ *
+ * When RUNAI_STREAMER_AZURE_CACHE_LIB is set to a path, the loader opens the library
+ * and resolves the runai_cache_read symbol. All subsequent blob reads can be
+ * served through the cache provider instead of Azure Blob Storage.
+ *
+ * Thread-safe singleton — initialization happens once on first access.
+ */
+class AzCacheProviderLoader
+{
+public:
+    static AzCacheProviderLoader& instance();
+
+    bool is_enabled() const { return _enabled.load(std::memory_order_relaxed); }
+
+    /**
+     * Read blob data through the cache provider.
+     *
+     * @param container  Azure container name
+     * @param blob       Blob path within the container
+     * @param buffer     Destination buffer (caller-allocated)
+     * @param offset     Byte offset within the blob
+     * @param length     Number of bytes to read
+     * @return true on success, false on error
+     */
+    bool read(const std::string& container,
+              const std::string& blob,
+              char* buffer,
+              size_t offset,
+              size_t length);
+
+    AzCacheProviderLoader(const AzCacheProviderLoader&) = delete;
+    AzCacheProviderLoader& operator=(const AzCacheProviderLoader&) = delete;
+
+private:
+    AzCacheProviderLoader();
+    ~AzCacheProviderLoader();
+
+    void* _lib_handle;
+    runai_cache_read_fn _cache_read;
+    std::atomic<bool> _enabled;
+    std::string _lib_path;
+};
+
+} // namespace runai::llm::streamer::impl::azure

--- a/cpp/azure/azcache_provider/azcache_provider_loader.h
+++ b/cpp/azure/azcache_provider/azcache_provider_loader.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <atomic>
-#include <mutex>
+#include <memory>
 #include <string>
 
 #include "azure/azcache_provider/runai_azcache_provider.h"
@@ -10,21 +9,52 @@ namespace runai::llm::streamer::impl::azure
 {
 
 /**
+ * Cache mode matching RUNAI_STREAMER_DIST pattern.
+ */
+enum class CacheMode
+{
+    Disabled,  // "0" — never use cache
+    Required,  // "1" — must load cache, fail if not found
+    Auto       // "auto" or unset — use if available, silently disable otherwise
+};
+
+/**
+ * Configuration for constructing a cache provider loader.
+ */
+struct CacheProviderConfig
+{
+    std::string lib_path;  // Path to the cache provider .so (empty = not configured)
+    CacheMode mode = CacheMode::Auto;
+};
+
+/**
  * AzCacheProviderLoader dynamically loads a cache provider .so at runtime
  * via dlopen/dlsym.
  *
- * Auto-discovers the cache library in Python site-packages (e.g., tachyon_client).
- * Can be disabled with RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_ENABLED=false.
- * Can be overridden with RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_LIB=/path/to.so.
+ * No longer a global singleton — owned by AzureClient for testability.
+ * Use from_env() to create from environment variables.
  *
- * Thread-safe singleton — initialization happens once on first access.
+ * Thread-safe once constructed (immutable state after construction).
  */
 class AzCacheProviderLoader
 {
 public:
-    static AzCacheProviderLoader& instance();
+    /**
+     * Create a loader from environment variables:
+     *   RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_ENABLED: "0", "1", or "auto" (default)
+     *   RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_LIB: explicit .so path override
+     *
+     * @throws common::Exception if mode=Required and library cannot be loaded.
+     */
+    static std::shared_ptr<AzCacheProviderLoader> from_env();
 
-    bool is_enabled() const { return _enabled.load(std::memory_order_relaxed); }
+    /**
+     * Create a loader with explicit configuration (for testing).
+     */
+    explicit AzCacheProviderLoader(const CacheProviderConfig& config);
+    ~AzCacheProviderLoader();
+
+    bool is_enabled() const { return _enabled; }
 
     /**
      * Read blob data through the cache provider.
@@ -35,7 +65,7 @@ public:
      * @param buffer     Destination buffer (caller-allocated)
      * @param offset     Byte offset within the blob
      * @param length     Number of bytes to read
-     * @return true on success, false on error
+     * @return true on success (length bytes read), false on error
      */
     bool read(const std::string& account,
               const std::string& container,
@@ -48,12 +78,9 @@ public:
     AzCacheProviderLoader& operator=(const AzCacheProviderLoader&) = delete;
 
 private:
-    AzCacheProviderLoader();
-    ~AzCacheProviderLoader();
-
     void* _lib_handle;
     blob_read_fn _cache_read;
-    std::atomic<bool> _enabled;
+    bool _enabled;
     std::string _lib_path;
 };
 

--- a/cpp/azure/azcache_provider/azcache_provider_test.cc
+++ b/cpp/azure/azcache_provider/azcache_provider_test.cc
@@ -1,0 +1,270 @@
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <vector>
+#include <dlfcn.h>
+
+#include "azure/azcache_provider/runai_azcache_provider.h"
+#include "azure/azcache_provider/azcache_provider_loader.h"
+
+namespace runai::llm::streamer::impl::azure::testing
+{
+
+namespace fs = std::filesystem;
+
+class SimpleFileCacheTest : public ::testing::Test
+{
+protected:
+    fs::path cache_dir_;
+    fs::path so_path_;
+
+    void SetUp() override
+    {
+        // Create a temp cache directory
+        cache_dir_ = fs::temp_directory_path() / ("runai_cache_test_" + std::to_string(getpid()));
+        fs::create_directories(cache_dir_);
+
+        // Locate the example .so built by Bazel
+        // Bazel puts genrule outputs relative to the runfiles directory
+        const char* test_srcdir = getenv("TEST_SRCDIR");
+        const char* test_workspace = getenv("TEST_WORKSPACE");
+        if (test_srcdir && test_workspace)
+        {
+            so_path_ = fs::path(test_srcdir) / test_workspace / "azure/azcache_provider/libsimple_file_cache_test.so";
+        }
+
+        // Fallback: try relative path from working directory
+        if (!fs::exists(so_path_))
+        {
+            so_path_ = "azure/azcache_provider/libsimple_file_cache_test.so";
+        }
+    }
+
+    void TearDown() override
+    {
+        fs::remove_all(cache_dir_);
+        unsetenv("RUNAI_CACHE_DIR");
+    }
+
+    // Write a test blob file into the cache directory
+    void populate_cache(const std::string& container, const std::string& blob,
+                        const std::vector<uint8_t>& data)
+    {
+        fs::path blob_path = cache_dir_ / container / blob;
+        fs::create_directories(blob_path.parent_path());
+        std::ofstream ofs(blob_path, std::ios::binary);
+        ofs.write(reinterpret_cast<const char*>(data.data()), data.size());
+    }
+
+    // Directly dlopen the example .so and return the function pointer
+    blob_read_fn load_cache_fn()
+    {
+        void* handle = dlopen(so_path_.c_str(), RTLD_NOW | RTLD_LOCAL);
+        if (!handle)
+        {
+            ADD_FAILURE() << "dlopen failed: " << dlerror();
+            return nullptr;
+        }
+        auto fn = reinterpret_cast<blob_read_fn>(
+            dlsym(handle, BLOB_READ_SYMBOL));
+        if (!fn)
+        {
+            ADD_FAILURE() << "dlsym failed: " << dlerror();
+        }
+        return fn;
+    }
+};
+
+TEST_F(SimpleFileCacheTest, ReadFullBlob)
+{
+    // Populate cache with test data
+    std::vector<uint8_t> data(1024);
+    for (size_t i = 0; i < data.size(); ++i)
+    {
+        data[i] = static_cast<uint8_t>(i & 0xFF);
+    }
+    populate_cache("test-container", "model/weights.bin", data);
+
+    setenv("RUNAI_CACHE_DIR", cache_dir_.c_str(), 1);
+
+    auto cache_read = load_cache_fn();
+    ASSERT_NE(cache_read, nullptr);
+
+    // Read the full blob
+    std::vector<uint8_t> buf(1024);
+    char* error = nullptr;
+    ssize_t result = cache_read("test-account", "test-container", "model/weights.bin",
+                                buf.data(), 0, 1024, &error);
+    ASSERT_EQ(result, 1024) << (error ? error : "no error detail");
+    EXPECT_EQ(error, nullptr);
+    EXPECT_EQ(buf, data);
+
+    if (error) free(error);
+}
+
+TEST_F(SimpleFileCacheTest, ReadRange)
+{
+    // Populate cache with sequential bytes
+    std::vector<uint8_t> data(4096);
+    for (size_t i = 0; i < data.size(); ++i)
+    {
+        data[i] = static_cast<uint8_t>(i % 251);  // prime to avoid aliasing
+    }
+    populate_cache("models", "llm/shard-0001.safetensors", data);
+
+    setenv("RUNAI_CACHE_DIR", cache_dir_.c_str(), 1);
+
+    auto cache_read = load_cache_fn();
+    ASSERT_NE(cache_read, nullptr);
+
+    // Read a range from the middle
+    size_t offset = 1000;
+    size_t length = 512;
+    std::vector<uint8_t> buf(length);
+    char* error = nullptr;
+
+    ssize_t result = cache_read("test-account", "models", "llm/shard-0001.safetensors",
+                                buf.data(), offset, length, &error);
+    ASSERT_EQ(result, static_cast<ssize_t>(length)) << (error ? error : "no error");
+    EXPECT_EQ(error, nullptr);
+
+    // Verify data matches the expected range
+    for (size_t i = 0; i < length; ++i)
+    {
+        EXPECT_EQ(buf[i], data[offset + i]) << "mismatch at offset " << (offset + i);
+    }
+
+    if (error) free(error);
+}
+
+TEST_F(SimpleFileCacheTest, MissingBlobReturnsError)
+{
+    setenv("RUNAI_CACHE_DIR", cache_dir_.c_str(), 1);
+
+    auto cache_read = load_cache_fn();
+    ASSERT_NE(cache_read, nullptr);
+
+    char buf[100];
+    char* error = nullptr;
+
+    ssize_t result = cache_read("test-account", "no-such-container", "no-such-blob",
+                                buf, 0, 100, &error);
+    EXPECT_EQ(result, -1);
+    EXPECT_NE(error, nullptr);
+    if (error)
+    {
+        EXPECT_NE(std::string(error).find("open failed"), std::string::npos);
+        free(error);
+    }
+}
+
+TEST_F(SimpleFileCacheTest, ShortReadReturnsError)
+{
+    // Populate cache with a small file
+    std::vector<uint8_t> data = {1, 2, 3, 4, 5};
+    populate_cache("c", "small.bin", data);
+
+    setenv("RUNAI_CACHE_DIR", cache_dir_.c_str(), 1);
+
+    auto cache_read = load_cache_fn();
+    ASSERT_NE(cache_read, nullptr);
+
+    // Try to read more than the file contains
+    char buf[100];
+    char* error = nullptr;
+
+    ssize_t result = cache_read("test-account", "c", "small.bin", buf, 0, 100, &error);
+    EXPECT_EQ(result, -1);
+    EXPECT_NE(error, nullptr);
+    if (error)
+    {
+        EXPECT_NE(std::string(error).find("short read"), std::string::npos);
+        free(error);
+    }
+}
+
+TEST_F(SimpleFileCacheTest, NullArgumentsReturnError)
+{
+    auto cache_read = load_cache_fn();
+    ASSERT_NE(cache_read, nullptr);
+
+    char* error = nullptr;
+    char buf[10];
+
+    EXPECT_EQ(cache_read(nullptr, "c", "blob", buf, 0, 10, &error), -1);
+    if (error) { free(error); error = nullptr; }
+
+    EXPECT_EQ(cache_read("a", nullptr, "blob", buf, 0, 10, &error), -1);
+    if (error) { free(error); error = nullptr; }
+
+    EXPECT_EQ(cache_read("a", "c", nullptr, buf, 0, 10, &error), -1);
+    if (error) { free(error); error = nullptr; }
+
+    EXPECT_EQ(cache_read("a", "c", "b", nullptr, 0, 10, &error), -1);
+    if (error) { free(error); error = nullptr; }
+}
+
+TEST_F(SimpleFileCacheTest, MultipleContainers)
+{
+    // Populate two containers with different data
+    std::vector<uint8_t> data_a = {10, 20, 30, 40};
+    std::vector<uint8_t> data_b = {50, 60, 70, 80};
+    populate_cache("container-a", "file.bin", data_a);
+    populate_cache("container-b", "file.bin", data_b);
+
+    setenv("RUNAI_CACHE_DIR", cache_dir_.c_str(), 1);
+
+    auto cache_read = load_cache_fn();
+    ASSERT_NE(cache_read, nullptr);
+
+    char buf[4];
+    char* error = nullptr;
+
+    ASSERT_EQ(cache_read("test-account", "container-a", "file.bin", buf, 0, 4, &error), 4);
+    EXPECT_EQ(memcmp(buf, data_a.data(), 4), 0);
+
+    ASSERT_EQ(cache_read("test-account", "container-b", "file.bin", buf, 0, 4, &error), 4);
+    EXPECT_EQ(memcmp(buf, data_b.data(), 4), 0);
+
+    if (error) free(error);
+}
+
+TEST_F(SimpleFileCacheTest, PathTraversalRejected)
+{
+    setenv("RUNAI_CACHE_DIR", cache_dir_.c_str(), 1);
+
+    auto cache_read = load_cache_fn();
+    ASSERT_NE(cache_read, nullptr);
+
+    char buf[10];
+    char* error = nullptr;
+
+    // ".." in container
+    EXPECT_EQ(cache_read("a", "../etc", "passwd", buf, 0, 10, &error), -1);
+    ASSERT_NE(error, nullptr);
+    EXPECT_NE(std::string(error).find("path traversal"), std::string::npos);
+    free(error); error = nullptr;
+
+    // ".." in blob
+    EXPECT_EQ(cache_read("a", "c", "../../etc/passwd", buf, 0, 10, &error), -1);
+    ASSERT_NE(error, nullptr);
+    EXPECT_NE(std::string(error).find("path traversal"), std::string::npos);
+    free(error); error = nullptr;
+
+    // ".." embedded in path
+    EXPECT_EQ(cache_read("a", "c", "sub/../../../etc/shadow", buf, 0, 10, &error), -1);
+    ASSERT_NE(error, nullptr);
+    EXPECT_NE(std::string(error).find("path traversal"), std::string::npos);
+    free(error); error = nullptr;
+
+    // "..." (not traversal) should NOT be rejected — will fail with open error instead
+    EXPECT_EQ(cache_read("a", "c", "...", buf, 0, 10, &error), -1);
+    ASSERT_NE(error, nullptr);
+    EXPECT_EQ(std::string(error).find("path traversal"), std::string::npos);
+    free(error); error = nullptr;
+}
+
+} // namespace runai::llm::streamer::impl::azure::testing

--- a/cpp/azure/azcache_provider/azcache_provider_test.cc
+++ b/cpp/azure/azcache_provider/azcache_provider_test.cc
@@ -1,0 +1,267 @@
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <vector>
+#include <dlfcn.h>
+
+#include "azure/azcache_provider/runai_azcache_provider.h"
+#include "azure/azcache_provider/azcache_provider_loader.h"
+
+namespace runai::llm::streamer::impl::azure::testing
+{
+
+namespace fs = std::filesystem;
+
+class SimpleFileCacheTest : public ::testing::Test
+{
+protected:
+    fs::path cache_dir_;
+    fs::path so_path_;
+
+    void SetUp() override
+    {
+        // Create a temp cache directory
+        cache_dir_ = fs::temp_directory_path() / ("runai_cache_test_" + std::to_string(getpid()));
+        fs::create_directories(cache_dir_);
+
+        // Locate the example .so built by Bazel
+        // Bazel puts genrule outputs relative to the runfiles directory
+        const char* test_srcdir = getenv("TEST_SRCDIR");
+        const char* test_workspace = getenv("TEST_WORKSPACE");
+        if (test_srcdir && test_workspace)
+        {
+            so_path_ = fs::path(test_srcdir) / test_workspace / "azure/azcache_provider/libsimple_file_cache.so";
+        }
+
+        // Fallback: try relative path from working directory
+        if (!fs::exists(so_path_))
+        {
+            so_path_ = "azure/azcache_provider/libsimple_file_cache.so";
+        }
+    }
+
+    void TearDown() override
+    {
+        fs::remove_all(cache_dir_);
+        unsetenv("RUNAI_CACHE_DIR");
+    }
+
+    // Write a test blob file into the cache directory
+    void populate_cache(const std::string& container, const std::string& blob,
+                        const std::vector<uint8_t>& data)
+    {
+        fs::path blob_path = cache_dir_ / container / blob;
+        fs::create_directories(blob_path.parent_path());
+        std::ofstream ofs(blob_path, std::ios::binary);
+        ofs.write(reinterpret_cast<const char*>(data.data()), data.size());
+    }
+
+    // Directly dlopen the example .so and return the function pointer
+    runai_cache_read_fn load_cache_fn()
+    {
+        void* handle = dlopen(so_path_.c_str(), RTLD_NOW | RTLD_LOCAL);
+        if (!handle)
+        {
+            ADD_FAILURE() << "dlopen failed: " << dlerror();
+            return nullptr;
+        }
+        auto fn = reinterpret_cast<runai_cache_read_fn>(
+            dlsym(handle, RUNAI_CACHE_READ_SYMBOL));
+        if (!fn)
+        {
+            ADD_FAILURE() << "dlsym failed: " << dlerror();
+        }
+        return fn;
+    }
+};
+
+TEST_F(SimpleFileCacheTest, ReadFullBlob)
+{
+    // Populate cache with test data
+    std::vector<uint8_t> data(1024);
+    for (size_t i = 0; i < data.size(); ++i)
+    {
+        data[i] = static_cast<uint8_t>(i & 0xFF);
+    }
+    populate_cache("test-container", "model/weights.bin", data);
+
+    setenv("RUNAI_CACHE_DIR", cache_dir_.c_str(), 1);
+
+    auto cache_read = load_cache_fn();
+    ASSERT_NE(cache_read, nullptr);
+
+    // Read the full blob
+    std::vector<uint8_t> buf(1024);
+    char* error = nullptr;
+    ssize_t result = cache_read("test-container", "model/weights.bin",
+                                buf.data(), 0, 1024, &error);
+    ASSERT_EQ(result, 1024) << (error ? error : "no error detail");
+    EXPECT_EQ(error, nullptr);
+    EXPECT_EQ(buf, data);
+
+    if (error) free(error);
+}
+
+TEST_F(SimpleFileCacheTest, ReadRange)
+{
+    // Populate cache with sequential bytes
+    std::vector<uint8_t> data(4096);
+    for (size_t i = 0; i < data.size(); ++i)
+    {
+        data[i] = static_cast<uint8_t>(i % 251);  // prime to avoid aliasing
+    }
+    populate_cache("models", "llm/shard-0001.safetensors", data);
+
+    setenv("RUNAI_CACHE_DIR", cache_dir_.c_str(), 1);
+
+    auto cache_read = load_cache_fn();
+    ASSERT_NE(cache_read, nullptr);
+
+    // Read a range from the middle
+    size_t offset = 1000;
+    size_t length = 512;
+    std::vector<uint8_t> buf(length);
+    char* error = nullptr;
+
+    ssize_t result = cache_read("models", "llm/shard-0001.safetensors",
+                                buf.data(), offset, length, &error);
+    ASSERT_EQ(result, static_cast<ssize_t>(length)) << (error ? error : "no error");
+    EXPECT_EQ(error, nullptr);
+
+    // Verify data matches the expected range
+    for (size_t i = 0; i < length; ++i)
+    {
+        EXPECT_EQ(buf[i], data[offset + i]) << "mismatch at offset " << (offset + i);
+    }
+
+    if (error) free(error);
+}
+
+TEST_F(SimpleFileCacheTest, MissingBlobReturnsError)
+{
+    setenv("RUNAI_CACHE_DIR", cache_dir_.c_str(), 1);
+
+    auto cache_read = load_cache_fn();
+    ASSERT_NE(cache_read, nullptr);
+
+    char buf[100];
+    char* error = nullptr;
+
+    ssize_t result = cache_read("no-such-container", "no-such-blob",
+                                buf, 0, 100, &error);
+    EXPECT_EQ(result, -1);
+    EXPECT_NE(error, nullptr);
+    if (error)
+    {
+        EXPECT_NE(std::string(error).find("open failed"), std::string::npos);
+        free(error);
+    }
+}
+
+TEST_F(SimpleFileCacheTest, ShortReadReturnsError)
+{
+    // Populate cache with a small file
+    std::vector<uint8_t> data = {1, 2, 3, 4, 5};
+    populate_cache("c", "small.bin", data);
+
+    setenv("RUNAI_CACHE_DIR", cache_dir_.c_str(), 1);
+
+    auto cache_read = load_cache_fn();
+    ASSERT_NE(cache_read, nullptr);
+
+    // Try to read more than the file contains
+    char buf[100];
+    char* error = nullptr;
+
+    ssize_t result = cache_read("c", "small.bin", buf, 0, 100, &error);
+    EXPECT_EQ(result, -1);
+    EXPECT_NE(error, nullptr);
+    if (error)
+    {
+        EXPECT_NE(std::string(error).find("short read"), std::string::npos);
+        free(error);
+    }
+}
+
+TEST_F(SimpleFileCacheTest, NullArgumentsReturnError)
+{
+    auto cache_read = load_cache_fn();
+    ASSERT_NE(cache_read, nullptr);
+
+    char* error = nullptr;
+    char buf[10];
+
+    EXPECT_EQ(cache_read(nullptr, "blob", buf, 0, 10, &error), -1);
+    if (error) { free(error); error = nullptr; }
+
+    EXPECT_EQ(cache_read("c", nullptr, buf, 0, 10, &error), -1);
+    if (error) { free(error); error = nullptr; }
+
+    EXPECT_EQ(cache_read("c", "b", nullptr, 0, 10, &error), -1);
+    if (error) { free(error); error = nullptr; }
+}
+
+TEST_F(SimpleFileCacheTest, MultipleContainers)
+{
+    // Populate two containers with different data
+    std::vector<uint8_t> data_a = {10, 20, 30, 40};
+    std::vector<uint8_t> data_b = {50, 60, 70, 80};
+    populate_cache("container-a", "file.bin", data_a);
+    populate_cache("container-b", "file.bin", data_b);
+
+    setenv("RUNAI_CACHE_DIR", cache_dir_.c_str(), 1);
+
+    auto cache_read = load_cache_fn();
+    ASSERT_NE(cache_read, nullptr);
+
+    char buf[4];
+    char* error = nullptr;
+
+    ASSERT_EQ(cache_read("container-a", "file.bin", buf, 0, 4, &error), 4);
+    EXPECT_EQ(memcmp(buf, data_a.data(), 4), 0);
+
+    ASSERT_EQ(cache_read("container-b", "file.bin", buf, 0, 4, &error), 4);
+    EXPECT_EQ(memcmp(buf, data_b.data(), 4), 0);
+
+    if (error) free(error);
+}
+
+TEST_F(SimpleFileCacheTest, PathTraversalRejected)
+{
+    setenv("RUNAI_CACHE_DIR", cache_dir_.c_str(), 1);
+
+    auto cache_read = load_cache_fn();
+    ASSERT_NE(cache_read, nullptr);
+
+    char buf[10];
+    char* error = nullptr;
+
+    // ".." in container
+    EXPECT_EQ(cache_read("../etc", "passwd", buf, 0, 10, &error), -1);
+    ASSERT_NE(error, nullptr);
+    EXPECT_NE(std::string(error).find("path traversal"), std::string::npos);
+    free(error); error = nullptr;
+
+    // ".." in blob
+    EXPECT_EQ(cache_read("c", "../../etc/passwd", buf, 0, 10, &error), -1);
+    ASSERT_NE(error, nullptr);
+    EXPECT_NE(std::string(error).find("path traversal"), std::string::npos);
+    free(error); error = nullptr;
+
+    // ".." embedded in path
+    EXPECT_EQ(cache_read("c", "sub/../../../etc/shadow", buf, 0, 10, &error), -1);
+    ASSERT_NE(error, nullptr);
+    EXPECT_NE(std::string(error).find("path traversal"), std::string::npos);
+    free(error); error = nullptr;
+
+    // "..." (not traversal) should NOT be rejected — will fail with open error instead
+    EXPECT_EQ(cache_read("c", "...", buf, 0, 10, &error), -1);
+    ASSERT_NE(error, nullptr);
+    EXPECT_EQ(std::string(error).find("path traversal"), std::string::npos);
+    free(error); error = nullptr;
+}
+
+} // namespace runai::llm::streamer::impl::azure::testing

--- a/cpp/azure/azcache_provider/azcache_provider_test.cc
+++ b/cpp/azure/azcache_provider/azcache_provider_test.cc
@@ -273,6 +273,74 @@ TEST_F(SimpleFileCacheTest, PathTraversalRejected)
     EXPECT_EQ(std::string(error_buf).find("path traversal"), std::string::npos);
 }
 
+// --- Shared handle tests ---
+
+TEST_F(SimpleFileCacheTest, SharedHandleMultipleLoadersSameLibrary)
+{
+    // Multiple loaders for the same library should share one CacheLibHandle
+    setenv("RUNAI_CACHE_DIR", cache_dir_.c_str(), 1);
+
+    CacheProviderConfig config;
+    config.mode = CacheMode::Auto;
+    config.lib_path = so_path_.string();
+
+    auto loader1 = std::make_shared<AzCacheProviderLoader>(config);
+    EXPECT_TRUE(loader1->is_enabled());
+
+    auto loader2 = std::make_shared<AzCacheProviderLoader>(config);
+    EXPECT_TRUE(loader2->is_enabled());
+
+    // Both should work
+    std::vector<uint8_t> data = {0xDE, 0xAD, 0xBE, 0xEF};
+    populate_cache("shared-test", "blob.bin", data);
+    char buf[4];
+    EXPECT_TRUE(loader1->read("acct", "shared-test", "blob.bin", buf, 0, 4));
+    EXPECT_TRUE(loader2->read("acct", "shared-test", "blob.bin", buf, 0, 4));
+
+    // Destroy first — cache should still work via second
+    loader1.reset();
+    EXPECT_TRUE(loader2->read("acct", "shared-test", "blob.bin", buf, 0, 4));
+}
+
+TEST_F(SimpleFileCacheTest, ShutdownCalledOnLastDestruction)
+{
+    setenv("RUNAI_CACHE_DIR", cache_dir_.c_str(), 1);
+
+    CacheProviderConfig config;
+    config.mode = CacheMode::Auto;
+    config.lib_path = so_path_.string();
+
+    // Load the .so to check shutdown_called() helper
+    void* handle = dlopen(so_path_.c_str(), RTLD_NOW | RTLD_LOCAL);
+    ASSERT_NE(handle, nullptr) << dlerror();
+    auto close_called_fn = reinterpret_cast<int(*)()>(dlsym(handle, "shutdown_called"));
+    ASSERT_NE(close_called_fn, nullptr);
+    auto reset_fn = reinterpret_cast<void(*)()>(dlsym(handle, "shutdown_reset"));
+    ASSERT_NE(reset_fn, nullptr);
+
+    // Reset state from any prior test (OS dedupes dlopen, so g_closed persists)
+    reset_fn();
+    EXPECT_EQ(close_called_fn(), 0);
+
+    {
+        auto loader1 = std::make_shared<AzCacheProviderLoader>(config);
+        EXPECT_TRUE(loader1->is_enabled());
+
+        auto loader2 = std::make_shared<AzCacheProviderLoader>(config);
+        EXPECT_TRUE(loader2->is_enabled());
+
+        // Destroy first loader — shutdown should NOT be called yet
+        loader1.reset();
+        EXPECT_EQ(close_called_fn(), 0);
+
+        // Destroy last loader — shutdown SHOULD be called
+        loader2.reset();
+    }
+
+    EXPECT_EQ(close_called_fn(), 1);
+    dlclose(handle);
+}
+
 // Test the AzCacheProviderLoader with explicit config
 TEST(CacheProviderLoaderTest, DisabledModeDoesNotLoad)
 {

--- a/cpp/azure/azcache_provider/azcache_provider_test.cc
+++ b/cpp/azure/azcache_provider/azcache_provider_test.cc
@@ -76,10 +76,33 @@ protected:
         }
         return fn;
     }
+
+    // Verify the .so exports a compatible ABI version
+    uint32_t load_abi_version()
+    {
+        void* handle = dlopen(so_path_.c_str(), RTLD_NOW | RTLD_LOCAL);
+        if (!handle)
+        {
+            ADD_FAILURE() << "dlopen failed: " << dlerror();
+            return 0;
+        }
+        auto version_fn = reinterpret_cast<runai_cache_abi_version_fn>(
+            dlsym(handle, RUNAI_CACHE_ABI_VERSION_SYMBOL));
+        if (!version_fn)
+        {
+            ADD_FAILURE() << "dlsym failed for " << RUNAI_CACHE_ABI_VERSION_SYMBOL << ": " << dlerror();
+            return 0;
+        }
+        return version_fn();
+    }
 };
 
 TEST_F(SimpleFileCacheTest, ReadFullBlob)
 {
+    // Verify ABI version is exported and matches expected
+    uint32_t version = load_abi_version();
+    ASSERT_EQ(version, RUNAI_CACHE_ABI_VERSION);
+
     // Populate cache with test data
     std::vector<uint8_t> data(1024);
     for (size_t i = 0; i < data.size(); ++i)
@@ -297,6 +320,211 @@ TEST(CacheProviderLoaderTest, RequiredModeInvalidPathThrows)
     config.lib_path = "/nonexistent/path/to/lib.so";
 
     EXPECT_THROW(AzCacheProviderLoader loader(config), std::exception);
+}
+
+// Helper: compile a minimal .so from source code string
+static std::string build_test_so(const std::string& source, const std::string& name)
+{
+    namespace fs = std::filesystem;
+    fs::path dir = fs::temp_directory_path() / ("abi_test_" + std::to_string(getpid()));
+    fs::create_directories(dir);
+
+    fs::path src_path = dir / (name + ".c");
+    fs::path so_path = dir / (name + ".so");
+
+    std::ofstream ofs(src_path);
+    ofs << source;
+    ofs.close();
+
+    std::string cmd = "gcc -shared -fPIC -o " + so_path.string() + " " + src_path.string() + " 2>/dev/null";
+    int ret = system(cmd.c_str());
+    if (ret != 0) return "";
+    return so_path.string();
+}
+
+// --- ABI version tests with CacheProviderLoader ---
+
+TEST(CacheProviderLoaderAbiTest, AutoModeNoVersionSymbolDisables)
+{
+    // .so with blob_read but no runai_cache_abi_version
+    std::string src = R"(
+#include <stddef.h>
+#include <sys/types.h>
+ssize_t blob_read(const char* a, const char* c, const char* b,
+    void* buf, size_t offset, size_t length,
+    char* err, size_t err_sz) { return (ssize_t)length; }
+)";
+    std::string path = build_test_so(src, "no_version");
+    ASSERT_FALSE(path.empty());
+
+    CacheProviderConfig config;
+    config.mode = CacheMode::Auto;
+    config.lib_path = path;
+
+    AzCacheProviderLoader loader(config);
+    EXPECT_FALSE(loader.is_enabled());
+
+    std::filesystem::remove_all(std::filesystem::path(path).parent_path());
+}
+
+TEST(CacheProviderLoaderAbiTest, RequiredModeNoVersionSymbolThrows)
+{
+    // .so with blob_read but no runai_cache_abi_version
+    std::string src = R"(
+#include <stddef.h>
+#include <sys/types.h>
+ssize_t blob_read(const char* a, const char* c, const char* b,
+    void* buf, size_t offset, size_t length,
+    char* err, size_t err_sz) { return (ssize_t)length; }
+)";
+    std::string path = build_test_so(src, "no_version_req");
+    ASSERT_FALSE(path.empty());
+
+    CacheProviderConfig config;
+    config.mode = CacheMode::Required;
+    config.lib_path = path;
+
+    EXPECT_THROW(AzCacheProviderLoader loader(config), std::exception);
+
+    std::filesystem::remove_all(std::filesystem::path(path).parent_path());
+}
+
+TEST(CacheProviderLoaderAbiTest, AutoModeVersionMismatchDisables)
+{
+    // .so with version returning 999 (wrong)
+    std::string src = R"(
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+uint32_t runai_cache_abi_version(void) { return 999; }
+ssize_t blob_read(const char* a, const char* c, const char* b,
+    void* buf, size_t offset, size_t length,
+    char* err, size_t err_sz) { return (ssize_t)length; }
+)";
+    std::string path = build_test_so(src, "bad_version");
+    ASSERT_FALSE(path.empty());
+
+    CacheProviderConfig config;
+    config.mode = CacheMode::Auto;
+    config.lib_path = path;
+
+    AzCacheProviderLoader loader(config);
+    EXPECT_FALSE(loader.is_enabled());
+
+    std::filesystem::remove_all(std::filesystem::path(path).parent_path());
+}
+
+TEST(CacheProviderLoaderAbiTest, RequiredModeVersionMismatchThrows)
+{
+    // .so with version returning 999 (wrong)
+    std::string src = R"(
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+uint32_t runai_cache_abi_version(void) { return 999; }
+ssize_t blob_read(const char* a, const char* c, const char* b,
+    void* buf, size_t offset, size_t length,
+    char* err, size_t err_sz) { return (ssize_t)length; }
+)";
+    std::string path = build_test_so(src, "bad_version_req");
+    ASSERT_FALSE(path.empty());
+
+    CacheProviderConfig config;
+    config.mode = CacheMode::Required;
+    config.lib_path = path;
+
+    EXPECT_THROW(AzCacheProviderLoader loader(config), std::exception);
+
+    std::filesystem::remove_all(std::filesystem::path(path).parent_path());
+}
+
+TEST(CacheProviderLoaderAbiTest, AutoModeVersionMatchEnables)
+{
+    // .so with correct version and valid blob_read
+    std::string src = R"(
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+uint32_t runai_cache_abi_version(void) { return 1; }
+ssize_t blob_read(const char* a, const char* c, const char* b,
+    void* buf, size_t offset, size_t length,
+    char* err, size_t err_sz) { return (ssize_t)length; }
+)";
+    std::string path = build_test_so(src, "good_version");
+    ASSERT_FALSE(path.empty());
+
+    CacheProviderConfig config;
+    config.mode = CacheMode::Auto;
+    config.lib_path = path;
+
+    AzCacheProviderLoader loader(config);
+    EXPECT_TRUE(loader.is_enabled());
+
+    std::filesystem::remove_all(std::filesystem::path(path).parent_path());
+}
+
+TEST(CacheProviderLoaderAbiTest, RequiredModeVersionMatchEnables)
+{
+    // .so with correct version and valid blob_read
+    std::string src = R"(
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+uint32_t runai_cache_abi_version(void) { return 1; }
+ssize_t blob_read(const char* a, const char* c, const char* b,
+    void* buf, size_t offset, size_t length,
+    char* err, size_t err_sz) { return (ssize_t)length; }
+)";
+    std::string path = build_test_so(src, "good_version_req");
+    ASSERT_FALSE(path.empty());
+
+    CacheProviderConfig config;
+    config.mode = CacheMode::Required;
+    config.lib_path = path;
+
+    AzCacheProviderLoader loader(config);
+    EXPECT_TRUE(loader.is_enabled());
+
+    std::filesystem::remove_all(std::filesystem::path(path).parent_path());
+}
+
+TEST(CacheProviderLoaderAbiTest, AutoModeVersionMatchNoBlobReadDisables)
+{
+    // .so with correct version but no blob_read symbol
+    std::string src = R"(
+#include <stdint.h>
+uint32_t runai_cache_abi_version(void) { return 1; }
+)";
+    std::string path = build_test_so(src, "no_blob_read");
+    ASSERT_FALSE(path.empty());
+
+    CacheProviderConfig config;
+    config.mode = CacheMode::Auto;
+    config.lib_path = path;
+
+    AzCacheProviderLoader loader(config);
+    EXPECT_FALSE(loader.is_enabled());
+
+    std::filesystem::remove_all(std::filesystem::path(path).parent_path());
+}
+
+TEST(CacheProviderLoaderAbiTest, RequiredModeVersionMatchNoBlobReadThrows)
+{
+    // .so with correct version but no blob_read symbol
+    std::string src = R"(
+#include <stdint.h>
+uint32_t runai_cache_abi_version(void) { return 1; }
+)";
+    std::string path = build_test_so(src, "no_blob_read_req");
+    ASSERT_FALSE(path.empty());
+
+    CacheProviderConfig config;
+    config.mode = CacheMode::Required;
+    config.lib_path = path;
+
+    EXPECT_THROW(AzCacheProviderLoader loader(config), std::exception);
+
+    std::filesystem::remove_all(std::filesystem::path(path).parent_path());
 }
 
 } // namespace runai::llm::streamer::impl::azure::testing

--- a/cpp/azure/azcache_provider/azcache_provider_test.cc
+++ b/cpp/azure/azcache_provider/azcache_provider_test.cc
@@ -95,14 +95,12 @@ TEST_F(SimpleFileCacheTest, ReadFullBlob)
 
     // Read the full blob
     std::vector<uint8_t> buf(1024);
-    char* error = nullptr;
+    char error_buf[RUNAI_CACHE_ERROR_BUF_SIZE] = {};
     ssize_t result = cache_read("test-account", "test-container", "model/weights.bin",
-                                buf.data(), 0, 1024, &error);
-    ASSERT_EQ(result, 1024) << (error ? error : "no error detail");
-    EXPECT_EQ(error, nullptr);
+                                buf.data(), 0, 1024, error_buf, sizeof(error_buf));
+    ASSERT_EQ(result, 1024) << (error_buf[0] ? error_buf : "no error detail");
+    EXPECT_EQ(error_buf[0], '\0');
     EXPECT_EQ(buf, data);
-
-    if (error) free(error);
 }
 
 TEST_F(SimpleFileCacheTest, ReadRange)
@@ -124,20 +122,18 @@ TEST_F(SimpleFileCacheTest, ReadRange)
     size_t offset = 1000;
     size_t length = 512;
     std::vector<uint8_t> buf(length);
-    char* error = nullptr;
+    char error_buf[RUNAI_CACHE_ERROR_BUF_SIZE] = {};
 
     ssize_t result = cache_read("test-account", "models", "llm/shard-0001.safetensors",
-                                buf.data(), offset, length, &error);
-    ASSERT_EQ(result, static_cast<ssize_t>(length)) << (error ? error : "no error");
-    EXPECT_EQ(error, nullptr);
+                                buf.data(), offset, length, error_buf, sizeof(error_buf));
+    ASSERT_EQ(result, static_cast<ssize_t>(length)) << (error_buf[0] ? error_buf : "no error");
+    EXPECT_EQ(error_buf[0], '\0');
 
     // Verify data matches the expected range
     for (size_t i = 0; i < length; ++i)
     {
         EXPECT_EQ(buf[i], data[offset + i]) << "mismatch at offset " << (offset + i);
     }
-
-    if (error) free(error);
 }
 
 TEST_F(SimpleFileCacheTest, MissingBlobReturnsError)
@@ -148,17 +144,13 @@ TEST_F(SimpleFileCacheTest, MissingBlobReturnsError)
     ASSERT_NE(cache_read, nullptr);
 
     char buf[100];
-    char* error = nullptr;
+    char error_buf[RUNAI_CACHE_ERROR_BUF_SIZE] = {};
 
     ssize_t result = cache_read("test-account", "no-such-container", "no-such-blob",
-                                buf, 0, 100, &error);
+                                buf, 0, 100, error_buf, sizeof(error_buf));
     EXPECT_EQ(result, -1);
-    EXPECT_NE(error, nullptr);
-    if (error)
-    {
-        EXPECT_NE(std::string(error).find("open failed"), std::string::npos);
-        free(error);
-    }
+    EXPECT_NE(error_buf[0], '\0');
+    EXPECT_NE(std::string(error_buf).find("open failed"), std::string::npos);
 }
 
 TEST_F(SimpleFileCacheTest, ShortReadReturnsError)
@@ -174,16 +166,13 @@ TEST_F(SimpleFileCacheTest, ShortReadReturnsError)
 
     // Try to read more than the file contains
     char buf[100];
-    char* error = nullptr;
+    char error_buf[RUNAI_CACHE_ERROR_BUF_SIZE] = {};
 
-    ssize_t result = cache_read("test-account", "c", "small.bin", buf, 0, 100, &error);
+    ssize_t result = cache_read("test-account", "c", "small.bin", buf, 0, 100,
+                                error_buf, sizeof(error_buf));
     EXPECT_EQ(result, -1);
-    EXPECT_NE(error, nullptr);
-    if (error)
-    {
-        EXPECT_NE(std::string(error).find("short read"), std::string::npos);
-        free(error);
-    }
+    EXPECT_NE(error_buf[0], '\0');
+    EXPECT_NE(std::string(error_buf).find("short read"), std::string::npos);
 }
 
 TEST_F(SimpleFileCacheTest, NullArgumentsReturnError)
@@ -191,20 +180,19 @@ TEST_F(SimpleFileCacheTest, NullArgumentsReturnError)
     auto cache_read = load_cache_fn();
     ASSERT_NE(cache_read, nullptr);
 
-    char* error = nullptr;
+    char error_buf[RUNAI_CACHE_ERROR_BUF_SIZE] = {};
     char buf[10];
 
-    EXPECT_EQ(cache_read(nullptr, "c", "blob", buf, 0, 10, &error), -1);
-    if (error) { free(error); error = nullptr; }
+    EXPECT_EQ(cache_read(nullptr, "c", "blob", buf, 0, 10, error_buf, sizeof(error_buf)), -1);
+    error_buf[0] = '\0';
 
-    EXPECT_EQ(cache_read("a", nullptr, "blob", buf, 0, 10, &error), -1);
-    if (error) { free(error); error = nullptr; }
+    EXPECT_EQ(cache_read("a", nullptr, "blob", buf, 0, 10, error_buf, sizeof(error_buf)), -1);
+    error_buf[0] = '\0';
 
-    EXPECT_EQ(cache_read("a", "c", nullptr, buf, 0, 10, &error), -1);
-    if (error) { free(error); error = nullptr; }
+    EXPECT_EQ(cache_read("a", "c", nullptr, buf, 0, 10, error_buf, sizeof(error_buf)), -1);
+    error_buf[0] = '\0';
 
-    EXPECT_EQ(cache_read("a", "c", "b", nullptr, 0, 10, &error), -1);
-    if (error) { free(error); error = nullptr; }
+    EXPECT_EQ(cache_read("a", "c", "b", nullptr, 0, 10, error_buf, sizeof(error_buf)), -1);
 }
 
 TEST_F(SimpleFileCacheTest, MultipleContainers)
@@ -221,15 +209,15 @@ TEST_F(SimpleFileCacheTest, MultipleContainers)
     ASSERT_NE(cache_read, nullptr);
 
     char buf[4];
-    char* error = nullptr;
+    char error_buf[RUNAI_CACHE_ERROR_BUF_SIZE] = {};
 
-    ASSERT_EQ(cache_read("test-account", "container-a", "file.bin", buf, 0, 4, &error), 4);
+    ASSERT_EQ(cache_read("test-account", "container-a", "file.bin", buf, 0, 4,
+                         error_buf, sizeof(error_buf)), 4);
     EXPECT_EQ(memcmp(buf, data_a.data(), 4), 0);
 
-    ASSERT_EQ(cache_read("test-account", "container-b", "file.bin", buf, 0, 4, &error), 4);
+    ASSERT_EQ(cache_read("test-account", "container-b", "file.bin", buf, 0, 4,
+                         error_buf, sizeof(error_buf)), 4);
     EXPECT_EQ(memcmp(buf, data_b.data(), 4), 0);
-
-    if (error) free(error);
 }
 
 TEST_F(SimpleFileCacheTest, PathTraversalRejected)
@@ -240,31 +228,75 @@ TEST_F(SimpleFileCacheTest, PathTraversalRejected)
     ASSERT_NE(cache_read, nullptr);
 
     char buf[10];
-    char* error = nullptr;
+    char error_buf[RUNAI_CACHE_ERROR_BUF_SIZE] = {};
 
     // ".." in container
-    EXPECT_EQ(cache_read("a", "../etc", "passwd", buf, 0, 10, &error), -1);
-    ASSERT_NE(error, nullptr);
-    EXPECT_NE(std::string(error).find("path traversal"), std::string::npos);
-    free(error); error = nullptr;
+    EXPECT_EQ(cache_read("a", "../etc", "passwd", buf, 0, 10, error_buf, sizeof(error_buf)), -1);
+    EXPECT_NE(std::string(error_buf).find("path traversal"), std::string::npos);
+    error_buf[0] = '\0';
 
     // ".." in blob
-    EXPECT_EQ(cache_read("a", "c", "../../etc/passwd", buf, 0, 10, &error), -1);
-    ASSERT_NE(error, nullptr);
-    EXPECT_NE(std::string(error).find("path traversal"), std::string::npos);
-    free(error); error = nullptr;
+    EXPECT_EQ(cache_read("a", "c", "../../etc/passwd", buf, 0, 10, error_buf, sizeof(error_buf)), -1);
+    EXPECT_NE(std::string(error_buf).find("path traversal"), std::string::npos);
+    error_buf[0] = '\0';
 
     // ".." embedded in path
-    EXPECT_EQ(cache_read("a", "c", "sub/../../../etc/shadow", buf, 0, 10, &error), -1);
-    ASSERT_NE(error, nullptr);
-    EXPECT_NE(std::string(error).find("path traversal"), std::string::npos);
-    free(error); error = nullptr;
+    EXPECT_EQ(cache_read("a", "c", "sub/../../../etc/shadow", buf, 0, 10, error_buf, sizeof(error_buf)), -1);
+    EXPECT_NE(std::string(error_buf).find("path traversal"), std::string::npos);
+    error_buf[0] = '\0';
 
     // "..." (not traversal) should NOT be rejected — will fail with open error instead
-    EXPECT_EQ(cache_read("a", "c", "...", buf, 0, 10, &error), -1);
-    ASSERT_NE(error, nullptr);
-    EXPECT_EQ(std::string(error).find("path traversal"), std::string::npos);
-    free(error); error = nullptr;
+    EXPECT_EQ(cache_read("a", "c", "...", buf, 0, 10, error_buf, sizeof(error_buf)), -1);
+    EXPECT_EQ(std::string(error_buf).find("path traversal"), std::string::npos);
+}
+
+// Test the AzCacheProviderLoader with explicit config
+TEST(CacheProviderLoaderTest, DisabledModeDoesNotLoad)
+{
+    CacheProviderConfig config;
+    config.mode = CacheMode::Disabled;
+    config.lib_path = "/nonexistent.so";
+
+    AzCacheProviderLoader loader(config);
+    EXPECT_FALSE(loader.is_enabled());
+}
+
+TEST(CacheProviderLoaderTest, AutoModeNoPathDisables)
+{
+    CacheProviderConfig config;
+    config.mode = CacheMode::Auto;
+    // lib_path empty
+
+    AzCacheProviderLoader loader(config);
+    EXPECT_FALSE(loader.is_enabled());
+}
+
+TEST(CacheProviderLoaderTest, AutoModeInvalidPathDisables)
+{
+    CacheProviderConfig config;
+    config.mode = CacheMode::Auto;
+    config.lib_path = "/nonexistent/path/to/lib.so";
+
+    AzCacheProviderLoader loader(config);
+    EXPECT_FALSE(loader.is_enabled());
+}
+
+TEST(CacheProviderLoaderTest, RequiredModeNoPathThrows)
+{
+    CacheProviderConfig config;
+    config.mode = CacheMode::Required;
+    // lib_path empty
+
+    EXPECT_THROW(AzCacheProviderLoader loader(config), std::exception);
+}
+
+TEST(CacheProviderLoaderTest, RequiredModeInvalidPathThrows)
+{
+    CacheProviderConfig config;
+    config.mode = CacheMode::Required;
+    config.lib_path = "/nonexistent/path/to/lib.so";
+
+    EXPECT_THROW(AzCacheProviderLoader loader(config), std::exception);
 }
 
 } // namespace runai::llm::streamer::impl::azure::testing

--- a/cpp/azure/azcache_provider/runai_azcache_provider.h
+++ b/cpp/azure/azcache_provider/runai_azcache_provider.h
@@ -1,0 +1,84 @@
+/*
+ * RunAI Azure Cache Provider Interface (Experimental)
+ *
+ * This header defines the contract for Azure Blob Storage cache providers.
+ * A cache provider is a shared library (.so) that exports the blob_read symbol.
+ * When installed as a Python package alongside runai-model-streamer, the cache
+ * provider is auto-discovered and loaded at runtime — no configuration needed.
+ *
+ * Control via environment variables:
+ *   RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_ENABLED=false  — disable cache entirely
+ *
+ * The cache provider is responsible for:
+ *   - Serving cached blob data when available
+ *   - Populating the cache (e.g., fetching from Azure Blob Storage on miss)
+ *   - Managing its own lifecycle and resources
+ *
+ * RunAI is NOT responsible for populating the cache.
+ *
+ * Example usage in a custom cache provider:
+ *
+ *   #include "runai_azcache_provider.h"
+ *
+ *   extern "C" ssize_t blob_read(
+ *       const char* account, const char* container,
+ *       const char* blob,
+ *       void* buf, size_t offset, size_t length,
+ *       char** error_string)
+ *   {
+ *       // Your cache logic here
+ *       return length;  // bytes read
+ *   }
+ */
+
+#ifndef RUNAI_STREAMER_AZCACHE_PROVIDER_H
+#define RUNAI_STREAMER_AZCACHE_PROVIDER_H
+
+#include <stddef.h>
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Read a range of bytes from a cached Azure blob.
+ *
+ * Parameters:
+ *   account      - Azure Storage account name
+ *   container    - Azure Blob Storage container name
+ *   blob         - Blob path within the container
+ *   buf          - Output buffer (caller-allocated, at least 'length' bytes)
+ *   offset       - Byte offset within the blob to start reading from
+ *   length       - Number of bytes to read
+ *   error_string - On failure, set to a malloc'd error message string.
+ *                  The caller is responsible for calling free() on it.
+ *                  May be set to NULL if no error detail is available.
+ *
+ * Returns:
+ *   Number of bytes read on success (should equal 'length').
+ *   -1 on error (error_string will be set if possible).
+ */
+typedef ssize_t (*blob_read_fn)(
+    const char* account,
+    const char* container,
+    const char* blob,
+    void* buf,
+    size_t offset,
+    size_t length,
+    char** error_string);
+
+/* Symbol name that the cache provider .so must export */
+#define BLOB_READ_SYMBOL "blob_read"
+
+/* Environment variable to enable/disable cache (master kill switch) */
+#define RUNAI_AZURE_CACHE_ENABLED_ENV "RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_ENABLED"
+
+/* Environment variable pointing to the cache provider .so path (internal override) */
+#define RUNAI_AZURE_CACHE_LIB_ENV "RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_LIB"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RUNAI_STREAMER_AZCACHE_PROVIDER_H */

--- a/cpp/azure/azcache_provider/runai_azcache_provider.h
+++ b/cpp/azure/azcache_provider/runai_azcache_provider.h
@@ -1,0 +1,77 @@
+/*
+ * RunAI Azure Cache Provider Interface
+ *
+ * This header defines the contract for Azure Blob Storage cache providers.
+ * Any shared library (.so) that exports the function below can be used as a
+ * cache provider for RunAI Model Streamer.
+ *
+ * To use a cache provider, set the environment variable:
+ *   RUNAI_STREAMER_AZURE_CACHE_LIB=/path/to/your_cache_provider.so
+ *
+ * The cache provider is responsible for:
+ *   - Serving cached blob data when available
+ *   - Populating the cache (e.g., fetching from Azure Blob Storage on miss)
+ *   - Managing its own lifecycle and resources
+ *
+ * RunAI is NOT responsible for populating the cache.
+ *
+ * Example usage in a custom cache provider:
+ *
+ *   #include "runai_azcache_provider.h"
+ *
+ *   extern "C" ssize_t runai_cache_read(
+ *       const char* container, const char* blob,
+ *       void* buf, size_t offset, size_t length,
+ *       char** error_string)
+ *   {
+ *       // Your cache logic here
+ *       return length;  // bytes read
+ *   }
+ */
+
+#ifndef RUNAI_STREAMER_AZCACHE_PROVIDER_H
+#define RUNAI_STREAMER_AZCACHE_PROVIDER_H
+
+#include <stddef.h>
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Read a range of bytes from a cached Azure blob.
+ *
+ * Parameters:
+ *   container    - Azure Blob Storage container name
+ *   blob         - Blob path within the container
+ *   buf          - Output buffer (caller-allocated, at least 'length' bytes)
+ *   offset       - Byte offset within the blob to start reading from
+ *   length       - Number of bytes to read
+ *   error_string - On failure, set to a malloc'd error message string.
+ *                  The caller is responsible for calling free() on it.
+ *                  May be set to NULL if no error detail is available.
+ *
+ * Returns:
+ *   Number of bytes read on success (should equal 'length').
+ *   -1 on error (error_string will be set if possible).
+ */
+typedef ssize_t (*runai_cache_read_fn)(
+    const char* container,
+    const char* blob,
+    void* buf,
+    size_t offset,
+    size_t length,
+    char** error_string);
+
+/* Symbol name that the cache provider .so must export */
+#define RUNAI_CACHE_READ_SYMBOL "runai_cache_read"
+
+/* Environment variable pointing to the cache provider .so path */
+#define RUNAI_AZURE_CACHE_LIB_ENV "RUNAI_STREAMER_AZURE_CACHE_LIB"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RUNAI_STREAMER_AZCACHE_PROVIDER_H */

--- a/cpp/azure/azcache_provider/runai_azcache_provider.h
+++ b/cpp/azure/azcache_provider/runai_azcache_provider.h
@@ -36,6 +36,11 @@
  *       // On error: snprintf(error_buf, error_buf_size, "details...");
  *       return length;  // bytes read on success, -1 on error
  *   }
+ *
+ *   extern "C" void shutdown(void) {
+ *       // Optional: graceful shutdown — stop threads, close connections.
+ *       // Called once when the streamer no longer needs the cache provider.
+ *   }
  */
 
 #ifndef RUNAI_STREAMER_AZCACHE_PROVIDER_H
@@ -87,6 +92,27 @@ typedef ssize_t (*blob_read_fn)(
 
 /* Symbol name that the cache provider .so must export */
 #define BLOB_READ_SYMBOL "blob_read"
+
+/*
+ * Optional: graceful shutdown of the cache provider.
+ *
+ * Called once when the streamer no longer needs the cache provider.
+ * The provider should stop background threads, close connections,
+ * and release resources. After shutdown() returns, no further
+ * blob_read() calls will be made.
+ *
+ * If the provider does not export this symbol, shutdown is skipped
+ * and resources are released at process exit by the OS.
+ *
+ * Contract:
+ *   - Called at most once per loaded library handle.
+ *   - Must not throw.
+ *   - Must be safe to call after all blob_read() calls have completed.
+ *   - Must tolerate partial initialization (e.g., if constructor failed midway).
+ */
+typedef void (*shutdown_fn)(void);
+
+#define SHUTDOWN_SYMBOL "shutdown"
 
 /*
  * ABI versioning — guards against incompatible .so after interface changes.

--- a/cpp/azure/azcache_provider/runai_azcache_provider.h
+++ b/cpp/azure/azcache_provider/runai_azcache_provider.h
@@ -22,6 +22,10 @@
  *
  *   #include "runai_azcache_provider.h"
  *
+ *   extern "C" uint32_t runai_cache_abi_version(void) {
+ *       return RUNAI_CACHE_ABI_VERSION;
+ *   }
+ *
  *   extern "C" ssize_t blob_read(
  *       const char* account, const char* container,
  *       const char* blob,
@@ -38,6 +42,7 @@
 #define RUNAI_STREAMER_AZCACHE_PROVIDER_H
 
 #include <stddef.h>
+#include <stdint.h>
 #include <sys/types.h>
 
 #ifdef __cplusplus
@@ -82,6 +87,18 @@ typedef ssize_t (*blob_read_fn)(
 
 /* Symbol name that the cache provider .so must export */
 #define BLOB_READ_SYMBOL "blob_read"
+
+/*
+ * ABI versioning — guards against incompatible .so after interface changes.
+ *
+ * The cache provider .so must export runai_cache_abi_version() returning
+ * RUNAI_CACHE_ABI_VERSION. The loader rejects libraries that do not export
+ * the symbol or return an unsupported version.
+ */
+#define RUNAI_CACHE_ABI_VERSION 1
+#define RUNAI_CACHE_ABI_VERSION_SYMBOL "runai_cache_abi_version"
+
+typedef uint32_t (*runai_cache_abi_version_fn)(void);
 
 /* Environment variable to control cache mode: "0", "1", or "auto" */
 #define RUNAI_AZURE_CACHE_ENABLED_ENV "RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_ENABLED"

--- a/cpp/azure/azcache_provider/runai_azcache_provider.h
+++ b/cpp/azure/azcache_provider/runai_azcache_provider.h
@@ -7,7 +7,9 @@
  * provider is auto-discovered and loaded at runtime — no configuration needed.
  *
  * Control via environment variables:
- *   RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_ENABLED=false  — disable cache entirely
+ *   RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_ENABLED=0    — disable cache entirely
+ *   RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_ENABLED=1    — require cache (fail if not found)
+ *   RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_ENABLED=auto — use if available (default)
  *
  * The cache provider is responsible for:
  *   - Serving cached blob data when available
@@ -24,10 +26,11 @@
  *       const char* account, const char* container,
  *       const char* blob,
  *       void* buf, size_t offset, size_t length,
- *       char** error_string)
+ *       char* error_buf, size_t error_buf_size)
  *   {
  *       // Your cache logic here
- *       return length;  // bytes read
+ *       // On error: snprintf(error_buf, error_buf_size, "details...");
+ *       return length;  // bytes read on success, -1 on error
  *   }
  */
 
@@ -41,23 +44,31 @@
 extern "C" {
 #endif
 
+/* Recommended error buffer size for callers */
+#define RUNAI_CACHE_ERROR_BUF_SIZE 512
+
 /*
  * Read a range of bytes from a cached Azure blob.
  *
  * Parameters:
- *   account      - Azure Storage account name
- *   container    - Azure Blob Storage container name
- *   blob         - Blob path within the container
- *   buf          - Output buffer (caller-allocated, at least 'length' bytes)
- *   offset       - Byte offset within the blob to start reading from
- *   length       - Number of bytes to read
- *   error_string - On failure, set to a malloc'd error message string.
- *                  The caller is responsible for calling free() on it.
- *                  May be set to NULL if no error detail is available.
+ *   account        - Azure Storage account name
+ *   container      - Azure Blob Storage container name
+ *   blob           - Blob path within the container
+ *   buf            - Output buffer (caller-allocated, at least 'length' bytes)
+ *   offset         - Byte offset within the blob to start reading from
+ *   length         - Number of bytes to read
+ *   error_buf      - Caller-owned buffer for error message (NUL-terminated on error).
+ *                    May be NULL if error_buf_size is 0 (errors are silently discarded).
+ *                    Message may be truncated if buffer is too small.
+ *   error_buf_size - Size of the error_buf in bytes
  *
  * Returns:
- *   Number of bytes read on success (should equal 'length').
- *   -1 on error (error_string will be set if possible).
+ *   Number of bytes read on success (must equal 'length' for success).
+ *   -1 on error (error_buf will contain a NUL-terminated message if provided).
+ *
+ * Contract:
+ *   - A return value != length is treated as an error by the caller.
+ *   - Providers must not return partial reads as success; return -1 instead.
  */
 typedef ssize_t (*blob_read_fn)(
     const char* account,
@@ -66,15 +77,16 @@ typedef ssize_t (*blob_read_fn)(
     void* buf,
     size_t offset,
     size_t length,
-    char** error_string);
+    char* error_buf,
+    size_t error_buf_size);
 
 /* Symbol name that the cache provider .so must export */
 #define BLOB_READ_SYMBOL "blob_read"
 
-/* Environment variable to enable/disable cache (master kill switch) */
+/* Environment variable to control cache mode: "0", "1", or "auto" */
 #define RUNAI_AZURE_CACHE_ENABLED_ENV "RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_ENABLED"
 
-/* Environment variable pointing to the cache provider .so path (internal override) */
+/* Environment variable pointing to the cache provider .so path (explicit override) */
 #define RUNAI_AZURE_CACHE_LIB_ENV "RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_LIB"
 
 #ifdef __cplusplus

--- a/cpp/azure/azcache_provider/simple_file_cache.cc
+++ b/cpp/azure/azcache_provider/simple_file_cache.cc
@@ -1,0 +1,133 @@
+/*
+ * Simple File-Based Cache Provider Example
+ *
+ * This is a reference implementation showing how to build a cache provider
+ * for RunAI Model Streamer. It stores cached blobs as plain files on disk:
+ *
+ *   <RUNAI_CACHE_DIR>/<container>/<blob>
+ *
+ * For example, if RUNAI_CACHE_DIR=/mnt/cache, a blob at
+ * container "models" path "llama/weights.safetensors" would be cached at:
+ *
+ *   /mnt/cache/models/llama/weights.safetensors
+ *
+ * The cache must be pre-populated (RunAI does not populate it).
+ *
+ * To build:
+ *   gcc -shared -fPIC -o libsimple_file_cache.so simple_file_cache.cc
+ *
+ * To use:
+ *   export RUNAI_STREAMER_AZURE_CACHE_LIB=/path/to/libsimple_file_cache.so
+ *   export RUNAI_CACHE_DIR=/mnt/cache
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static const char* get_cache_dir(void)
+{
+    const char* dir = getenv("RUNAI_CACHE_DIR");
+    return dir ? dir : "/mnt/cache";
+}
+
+static char* make_error(const char* msg)
+{
+    return strdup(msg);
+}
+
+/* Reject ".." as a path component to prevent path traversal attacks. */
+static int has_path_traversal(const char* s)
+{
+    const char* p = s;
+    while ((p = strstr(p, "..")) != NULL)
+    {
+        int at_start = (p == s || *(p - 1) == '/');
+        int at_end   = (*(p + 2) == '\0' || *(p + 2) == '/');
+        if (at_start && at_end) return 1;
+        p += 2;
+    }
+    return 0;
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+__attribute__((visibility("default")))
+ssize_t runai_cache_read(
+    const char* container,
+    const char* blob,
+    void* buf,
+    size_t offset,
+    size_t length,
+    char** error_string)
+{
+    if (!error_string)
+    {
+        return -1;
+    }
+    *error_string = NULL;
+
+    if (!container || !blob || !buf)
+    {
+        *error_string = make_error("null argument");
+        return -1;
+    }
+
+    if (has_path_traversal(container) || has_path_traversal(blob))
+    {
+        *error_string = make_error("path traversal rejected");
+        return -1;
+    }
+
+    /* Build path: <cache_dir>/<container>/<blob> */
+    const char* cache_dir = get_cache_dir();
+    char path[4096];
+    int n = snprintf(path, sizeof(path), "%s/%s/%s", cache_dir, container, blob);
+    if (n < 0 || (size_t)n >= sizeof(path))
+    {
+        *error_string = make_error("cache path too long");
+        return -1;
+    }
+
+    int fd = open(path, O_RDONLY);
+    if (fd < 0)
+    {
+        char err_buf[4200];
+        snprintf(err_buf, sizeof(err_buf), "open failed for '%s': %s", path, strerror(errno));
+        *error_string = make_error(err_buf);
+        return -1;
+    }
+
+    ssize_t bytes_read = pread(fd, buf, length, (off_t)offset);
+    if (bytes_read < 0)
+    {
+        char err_buf[4200];
+        snprintf(err_buf, sizeof(err_buf), "pread failed for '%s': %s", path, strerror(errno));
+        *error_string = make_error(err_buf);
+        close(fd);
+        return -1;
+    }
+
+    close(fd);
+
+    if ((size_t)bytes_read != length)
+    {
+        char err_buf[4200];
+        snprintf(err_buf, sizeof(err_buf),
+                 "short read for '%s': expected %zu bytes, got %zd",
+                 path, length, bytes_read);
+        *error_string = make_error(err_buf);
+        return -1;
+    }
+
+    return bytes_read;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/cpp/azure/azcache_provider/simple_file_cache_test.cc
+++ b/cpp/azure/azcache_provider/simple_file_cache_test.cc
@@ -1,0 +1,141 @@
+/*
+ * Simple File-Based Cache Provider — TEST ONLY
+ *
+ * This is a minimal test implementation of the blob_read interface.
+ * It serves cached blobs from local files on disk:
+ *
+ *   <RUNAI_CACHE_DIR>/<container>/<blob>
+ *
+ * For example, if RUNAI_CACHE_DIR=/mnt/cache, a blob at
+ * container "models" path "llama/weights.safetensors" would be cached at:
+ *
+ *   /mnt/cache/models/llama/weights.safetensors
+ *
+ * This test implementation does NOT fall back to Azure Blob Storage on a
+ * cache miss — it simply returns an error. A production cache provider
+ * should fetch from Azure Blob Storage when data is not in the cache,
+ * store it locally, and serve the read from the newly cached copy.
+ *
+ * The cache must be pre-populated before use (e.g., by the test harness).
+ *
+ * To build:
+ *   gcc -shared -fPIC -o libsimple_file_cache_test.so simple_file_cache_test.cc
+ *
+ * To use:
+ *   export RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_LIB=/path/to/libsimple_file_cache_test.so
+ *   export RUNAI_CACHE_DIR=/mnt/cache
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static const char* get_cache_dir(void)
+{
+    const char* dir = getenv("RUNAI_CACHE_DIR");
+    return dir ? dir : "/mnt/cache";
+}
+
+static char* make_error(const char* msg)
+{
+    return strdup(msg);
+}
+
+/* Reject absolute paths and ".." components to prevent path traversal attacks. */
+static int has_path_traversal(const char* s)
+{
+    if (s[0] == '/')
+        return 1;
+    const char* p = s;
+    while ((p = strstr(p, "..")) != NULL)
+    {
+        int at_start = (p == s || *(p - 1) == '/');
+        int at_end   = (*(p + 2) == '\0' || *(p + 2) == '/');
+        if (at_start && at_end) return 1;
+        p += 2;
+    }
+    return 0;
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+__attribute__((visibility("default")))
+ssize_t blob_read(
+    const char* account,
+    const char* container,
+    const char* blob,
+    void* buf,
+    size_t offset,
+    size_t length,
+    char** error_string)
+{
+    if (!error_string)
+    {
+        return -1;
+    }
+    *error_string = NULL;
+
+    if (!account || !container || !blob || !buf)
+    {
+        *error_string = make_error("null argument");
+        return -1;
+    }
+
+    if (has_path_traversal(container) || has_path_traversal(blob))
+    {
+        *error_string = make_error("path traversal rejected");
+        return -1;
+    }
+
+    /* Build path: <cache_dir>/<container>/<blob> */
+    const char* cache_dir = get_cache_dir();
+    char path[4096];
+    int n = snprintf(path, sizeof(path), "%s/%s/%s", cache_dir, container, blob);
+    if (n < 0 || (size_t)n >= sizeof(path))
+    {
+        *error_string = make_error("cache path too long");
+        return -1;
+    }
+
+    int fd = open(path, O_RDONLY);
+    if (fd < 0)
+    {
+        char err_buf[4200];
+        snprintf(err_buf, sizeof(err_buf), "open failed for '%s': %s", path, strerror(errno));
+        *error_string = make_error(err_buf);
+        return -1;
+    }
+
+    ssize_t bytes_read = pread(fd, buf, length, (off_t)offset);
+    if (bytes_read < 0)
+    {
+        char err_buf[4200];
+        snprintf(err_buf, sizeof(err_buf), "pread failed for '%s': %s", path, strerror(errno));
+        *error_string = make_error(err_buf);
+        close(fd);
+        return -1;
+    }
+
+    close(fd);
+
+    if ((size_t)bytes_read != length)
+    {
+        char err_buf[4200];
+        snprintf(err_buf, sizeof(err_buf),
+                 "short read for '%s': expected %zu bytes, got %zd",
+                 path, length, bytes_read);
+        *error_string = make_error(err_buf);
+        return -1;
+    }
+
+    return bytes_read;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/cpp/azure/azcache_provider/simple_file_cache_test.cc
+++ b/cpp/azure/azcache_provider/simple_file_cache_test.cc
@@ -19,7 +19,7 @@
  * The cache must be pre-populated before use (e.g., by the test harness).
  *
  * To build:
- *   gcc -shared -fPIC -o libsimple_file_cache_test.so simple_file_cache_test.cc
+ *   g++ -shared -fPIC -o libsimple_file_cache_test.so simple_file_cache_test.cc
  *
  * To use:
  *   export RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_LIB=/path/to/libsimple_file_cache_test.so
@@ -28,6 +28,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -39,9 +40,18 @@ static const char* get_cache_dir(void)
     return dir ? dir : "/mnt/cache";
 }
 
-static char* make_error(const char* msg)
+static void set_error(char* error_buf, size_t error_buf_size, const char* fmt, ...)
+    __attribute__((format(printf, 3, 4)));
+
+static void set_error(char* error_buf, size_t error_buf_size, const char* fmt, ...)
 {
-    return strdup(msg);
+    if (error_buf && error_buf_size > 0)
+    {
+        va_list args;
+        va_start(args, fmt);
+        vsnprintf(error_buf, error_buf_size, fmt, args);
+        va_end(args);
+    }
 }
 
 /* Reject absolute paths and ".." components to prevent path traversal attacks. */
@@ -72,23 +82,18 @@ ssize_t blob_read(
     void* buf,
     size_t offset,
     size_t length,
-    char** error_string)
+    char* error_buf,
+    size_t error_buf_size)
 {
-    if (!error_string)
-    {
-        return -1;
-    }
-    *error_string = NULL;
-
     if (!account || !container || !blob || !buf)
     {
-        *error_string = make_error("null argument");
+        set_error(error_buf, error_buf_size, "null argument");
         return -1;
     }
 
     if (has_path_traversal(container) || has_path_traversal(blob))
     {
-        *error_string = make_error("path traversal rejected");
+        set_error(error_buf, error_buf_size, "path traversal rejected");
         return -1;
     }
 
@@ -98,25 +103,21 @@ ssize_t blob_read(
     int n = snprintf(path, sizeof(path), "%s/%s/%s", cache_dir, container, blob);
     if (n < 0 || (size_t)n >= sizeof(path))
     {
-        *error_string = make_error("cache path too long");
+        set_error(error_buf, error_buf_size, "cache path too long");
         return -1;
     }
 
     int fd = open(path, O_RDONLY);
     if (fd < 0)
     {
-        char err_buf[4200];
-        snprintf(err_buf, sizeof(err_buf), "open failed for '%s': %s", path, strerror(errno));
-        *error_string = make_error(err_buf);
+        set_error(error_buf, error_buf_size, "open failed for '%s': %s", path, strerror(errno));
         return -1;
     }
 
     ssize_t bytes_read = pread(fd, buf, length, (off_t)offset);
     if (bytes_read < 0)
     {
-        char err_buf[4200];
-        snprintf(err_buf, sizeof(err_buf), "pread failed for '%s': %s", path, strerror(errno));
-        *error_string = make_error(err_buf);
+        set_error(error_buf, error_buf_size, "pread failed for '%s': %s", path, strerror(errno));
         close(fd);
         return -1;
     }
@@ -125,11 +126,9 @@ ssize_t blob_read(
 
     if ((size_t)bytes_read != length)
     {
-        char err_buf[4200];
-        snprintf(err_buf, sizeof(err_buf),
+        set_error(error_buf, error_buf_size,
                  "short read for '%s': expected %zu bytes, got %zd",
                  path, length, bytes_read);
-        *error_string = make_error(err_buf);
         return -1;
     }
 

--- a/cpp/azure/azcache_provider/simple_file_cache_test.cc
+++ b/cpp/azure/azcache_provider/simple_file_cache_test.cc
@@ -71,6 +71,8 @@ static int has_path_traversal(const char* s)
     return 0;
 }
 
+static int g_closed = 0;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -79,6 +81,24 @@ __attribute__((visibility("default")))
 uint32_t runai_cache_abi_version(void)
 {
     return 1;
+}
+
+__attribute__((visibility("default")))
+void shutdown(void)
+{
+    g_closed = 1;
+}
+
+__attribute__((visibility("default")))
+int shutdown_called(void)
+{
+    return g_closed;
+}
+
+__attribute__((visibility("default")))
+void shutdown_reset(void)
+{
+    g_closed = 0;
 }
 
 __attribute__((visibility("default")))

--- a/cpp/azure/azcache_provider/simple_file_cache_test.cc
+++ b/cpp/azure/azcache_provider/simple_file_cache_test.cc
@@ -29,6 +29,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -73,6 +74,12 @@ static int has_path_traversal(const char* s)
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+__attribute__((visibility("default")))
+uint32_t runai_cache_abi_version(void)
+{
+    return 1;
+}
 
 __attribute__((visibility("default")))
 ssize_t blob_read(

--- a/cpp/azure/client/async_azure_client/BUILD
+++ b/cpp/azure/client/async_azure_client/BUILD
@@ -4,6 +4,7 @@ cc_library(
     hdrs = ["async_azure_client.h"],
     visibility = ["//azure:__subpackages__"],
     deps = [
+        "//azure/azcache_provider",
         "//common/response_code",
         "//utils/threadpool",
         "//utils/logging",

--- a/cpp/azure/client/async_azure_client/async_azure_client.cc
+++ b/cpp/azure/client/async_azure_client/async_azure_client.cc
@@ -33,7 +33,8 @@ AsyncAzureClient::AsyncAzureClient(std::shared_ptr<Azure::Storage::Blobs::BlobSe
     _client(client),
     _pool([](DownloadBlobTask&& task, std::atomic<bool>& stopped) {
         task.execute();
-    }, max_pool_size)
+    }, max_pool_size),
+    _cache_enabled(AzCacheProviderLoader::instance().is_enabled())
 {
 }
 

--- a/cpp/azure/client/async_azure_client/async_azure_client.cc
+++ b/cpp/azure/client/async_azure_client/async_azure_client.cc
@@ -29,12 +29,16 @@ void DownloadBlobTask::execute() {
     }
 }
 
-AsyncAzureClient::AsyncAzureClient(std::shared_ptr<Azure::Storage::Blobs::BlobServiceClient> client, unsigned int max_pool_size) :
+AsyncAzureClient::AsyncAzureClient(
+    std::shared_ptr<Azure::Storage::Blobs::BlobServiceClient> client,
+    unsigned int max_pool_size,
+    std::shared_ptr<AzCacheProviderLoader> cache_loader) :
     _client(client),
     _pool([](DownloadBlobTask&& task, std::atomic<bool>& stopped) {
         task.execute();
     }, max_pool_size),
-    _cache_enabled(AzCacheProviderLoader::instance().is_enabled())
+    _cache_loader(std::move(cache_loader)),
+    _cache_enabled(_cache_loader && _cache_loader->is_enabled())
 {
 }
 

--- a/cpp/azure/client/async_azure_client/async_azure_client.h
+++ b/cpp/azure/client/async_azure_client/async_azure_client.h
@@ -10,6 +10,7 @@
 #include "common/response_code/response_code.h"
 #include "utils/logging/logging.h"
 #include "utils/threadpool/threadpool.h"
+#include "azure/azcache_provider/azcache_provider_loader.h"
 
 namespace runai::llm::streamer::impl::azure
 {
@@ -56,13 +57,26 @@ inline DownloadBlobFn createDownloadBlobFn(
 /**
  * An async wrapper for Azure Blob Storage client operations.
  * Uses ThreadPool to manage concurrent blob download operations.
+ * 
+ * When a cache provider is configured (via RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_LIB),
+ * the client will read from the cache instead of Azure Blob Storage.
  */
 struct AsyncAzureClient
 {
 public:
     AsyncAzureClient(std::shared_ptr<Azure::Storage::Blobs::BlobServiceClient> client, unsigned max_pool_size);
 
-    inline void DownloadBlobRangeAsync(
+    /** Returns true when a cache provider .so has been loaded (cached at construction). */
+    bool is_cache_enabled() const { return _cache_enabled; }
+
+    /**
+     * Download a range of a blob asynchronously.
+     * 
+     * When a cache provider is loaded, all reads are served from the cache.
+     * The cache provider is responsible for handling cache misses internally.
+     */
+    void DownloadBlobRangeAsync(
+        const std::string& account_name,
         const std::string& container_name,
         const std::string& blob_name,
         char* buffer,
@@ -70,14 +84,32 @@ public:
         size_t length,
         CompletionCallback callback)
     {
-        DownloadBlobFn downloadFn = createDownloadBlobFn(_client, container_name, blob_name, buffer, offset, length);
+        if (_cache_enabled)
+        {
+            DownloadBlobTask task{
+                [account_name, container_name, blob_name, buffer, offset, length]() {
+                    bool ok = AzCacheProviderLoader::instance().read(
+                        account_name, container_name, blob_name, buffer, offset, length);
+                    if (!ok)
+                    {
+                        throw std::runtime_error("Cache provider read failed");
+                    }
+                },
+                std::move(callback)
+            };
+            push_task(std::move(task));
+        }
+        else
+        {
+            DownloadBlobFn downloadFn = createDownloadBlobFn(_client, container_name, blob_name, buffer, offset, length);
 
-        DownloadBlobTask task{
-            std::move(downloadFn),
-            std::move(callback)
-        };
+            DownloadBlobTask task{
+                std::move(downloadFn),
+                std::move(callback)
+            };
 
-        push_task(std::move(task));
+            push_task(std::move(task));
+        }
     }
 
 private:
@@ -85,6 +117,7 @@ private:
 
     std::shared_ptr<Azure::Storage::Blobs::BlobServiceClient> _client;
     utils::ThreadPool<DownloadBlobTask> _pool;
+    const bool _cache_enabled;  // snapshot of cache state at construction
 };
 
 }; // namespace runai::llm::streamer::impl::azure

--- a/cpp/azure/client/async_azure_client/async_azure_client.h
+++ b/cpp/azure/client/async_azure_client/async_azure_client.h
@@ -58,15 +58,17 @@ inline DownloadBlobFn createDownloadBlobFn(
  * An async wrapper for Azure Blob Storage client operations.
  * Uses ThreadPool to manage concurrent blob download operations.
  * 
- * When a cache provider is configured (via RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_LIB),
- * the client will read from the cache instead of Azure Blob Storage.
+ * When a cache provider is configured, the client will read from
+ * the cache instead of Azure Blob Storage.
  */
 struct AsyncAzureClient
 {
 public:
-    AsyncAzureClient(std::shared_ptr<Azure::Storage::Blobs::BlobServiceClient> client, unsigned max_pool_size);
+    AsyncAzureClient(std::shared_ptr<Azure::Storage::Blobs::BlobServiceClient> client,
+                     unsigned max_pool_size,
+                     std::shared_ptr<AzCacheProviderLoader> cache_loader = nullptr);
 
-    /** Returns true when a cache provider .so has been loaded (cached at construction). */
+    /** Returns true when a cache provider .so has been loaded. */
     bool is_cache_enabled() const { return _cache_enabled; }
 
     /**
@@ -86,9 +88,11 @@ public:
     {
         if (_cache_enabled)
         {
+            // Capture shared_ptr to loader to ensure lifetime
+            auto loader = _cache_loader;
             DownloadBlobTask task{
-                [account_name, container_name, blob_name, buffer, offset, length]() {
-                    bool ok = AzCacheProviderLoader::instance().read(
+                [loader, account_name, container_name, blob_name, buffer, offset, length]() {
+                    bool ok = loader->read(
                         account_name, container_name, blob_name, buffer, offset, length);
                     if (!ok)
                     {
@@ -117,7 +121,8 @@ private:
 
     std::shared_ptr<Azure::Storage::Blobs::BlobServiceClient> _client;
     utils::ThreadPool<DownloadBlobTask> _pool;
-    const bool _cache_enabled;  // snapshot of cache state at construction
+    std::shared_ptr<AzCacheProviderLoader> _cache_loader;
+    const bool _cache_enabled;
 };
 
 }; // namespace runai::llm::streamer::impl::azure

--- a/cpp/azure/client/async_azure_client/async_azure_client.h
+++ b/cpp/azure/client/async_azure_client/async_azure_client.h
@@ -10,6 +10,7 @@
 #include "common/response_code/response_code.h"
 #include "utils/logging/logging.h"
 #include "utils/threadpool/threadpool.h"
+#include "azure/azcache_provider/azcache_provider_loader.h"
 
 namespace runai::llm::streamer::impl::azure
 {
@@ -56,13 +57,28 @@ inline DownloadBlobFn createDownloadBlobFn(
 /**
  * An async wrapper for Azure Blob Storage client operations.
  * Uses ThreadPool to manage concurrent blob download operations.
+ * 
+ * When a cache provider is configured (via RUNAI_STREAMER_AZURE_CACHE_LIB),
+ * the client will read from the cache instead of Azure Blob Storage.
  */
 struct AsyncAzureClient
 {
 public:
     AsyncAzureClient(std::shared_ptr<Azure::Storage::Blobs::BlobServiceClient> client, unsigned max_pool_size);
 
-    inline void DownloadBlobRangeAsync(
+    /** Returns true when a cache provider .so has been loaded. */
+    bool is_cache_enabled() const
+    {
+        return AzCacheProviderLoader::instance().is_enabled();
+    }
+
+    /**
+     * Download a range of a blob asynchronously.
+     * 
+     * When a cache provider is loaded, all reads are served from the cache.
+     * The cache provider is responsible for handling cache misses internally.
+     */
+    void DownloadBlobRangeAsync(
         const std::string& container_name,
         const std::string& blob_name,
         char* buffer,
@@ -70,14 +86,32 @@ public:
         size_t length,
         CompletionCallback callback)
     {
-        DownloadBlobFn downloadFn = createDownloadBlobFn(_client, container_name, blob_name, buffer, offset, length);
+        if (AzCacheProviderLoader::instance().is_enabled())
+        {
+            DownloadBlobTask task{
+                [container_name, blob_name, buffer, offset, length]() {
+                    bool ok = AzCacheProviderLoader::instance().read(
+                        container_name, blob_name, buffer, offset, length);
+                    if (!ok)
+                    {
+                        throw std::runtime_error("Cache provider read failed");
+                    }
+                },
+                std::move(callback)
+            };
+            push_task(std::move(task));
+        }
+        else
+        {
+            DownloadBlobFn downloadFn = createDownloadBlobFn(_client, container_name, blob_name, buffer, offset, length);
 
-        DownloadBlobTask task{
-            std::move(downloadFn),
-            std::move(callback)
-        };
+            DownloadBlobTask task{
+                std::move(downloadFn),
+                std::move(callback)
+            };
 
-        push_task(std::move(task));
+            push_task(std::move(task));
+        }
     }
 
 private:

--- a/cpp/azure/client/client.cc
+++ b/cpp/azure/client/client.cc
@@ -195,8 +195,18 @@ common::ResponseCode AzureClient::async_read(const char* path,
 
     char * buffer_ = destination_buffer;
 
-    // Split range into chunks
-    size_t num_chunks = std::max(1UL, range.length / _chunk_bytesize);
+    // Split range into chunks.
+    // When a cache provider is loaded, issue a single read per range
+    // so the provider can handle alignment and prefetching internally.
+    size_t num_chunks;
+    if (_async_client->is_cache_enabled())
+    {
+        num_chunks = 1;
+    }
+    else
+    {
+        num_chunks = std::max(1UL, range.length / _chunk_bytesize);
+    }
     LOG(SPAM) << "Number of chunks is: " << num_chunks;
 
     // Counter for tracking chunk completions
@@ -221,6 +231,7 @@ common::ResponseCode AzureClient::async_read(const char* path,
         
         // Launch async download with callback - AsyncAzureClient ThreadPool handles both download and callback
         _async_client->DownloadBlobRangeAsync(
+            _account_name.value_or(""),
             container_name,
             blob_name,
             chunk_buffer,

--- a/cpp/azure/client/client.cc
+++ b/cpp/azure/client/client.cc
@@ -195,8 +195,18 @@ common::ResponseCode AzureClient::async_read(const char* path,
 
     char * buffer_ = destination_buffer;
 
-    // Split range into chunks
-    size_t num_chunks = std::max(1UL, range.length / _chunk_bytesize);
+    // Split range into chunks.
+    // When a cache provider is loaded, issue a single read per range
+    // so the provider can handle alignment and prefetching internally.
+    size_t num_chunks;
+    if (_async_client->is_cache_enabled())
+    {
+        num_chunks = 1;
+    }
+    else
+    {
+        num_chunks = std::max(1UL, range.length / _chunk_bytesize);
+    }
     LOG(SPAM) << "Number of chunks is: " << num_chunks;
 
     // Counter for tracking chunk completions

--- a/cpp/azure/client/client.cc
+++ b/cpp/azure/client/client.cc
@@ -14,6 +14,7 @@
 #include <azure/core/exception.hpp>
 
 #include "azure/client/client.h"
+#include "azure/azcache_provider/azcache_provider_loader.h"
 #include "common/exception/exception.h"
 #include "utils/logging/logging.h"
 #include "utils/env/env.h"
@@ -105,8 +106,11 @@ AzureClient::AzureClient(const common::backend_api::ObjectClientConfig_t& config
             throw common::Exception(common::ResponseCode::InvalidParameterError);
         }
 
-        // Create async client with ThreadPool
-        _async_client = std::make_unique<AsyncAzureClient>(_blob_service_client, _client_config.max_concurrency);
+        // Create cache provider loader from environment
+        auto cache_loader = AzCacheProviderLoader::from_env();
+
+        // Create async client with ThreadPool and cache loader
+        _async_client = std::make_unique<AsyncAzureClient>(_blob_service_client, _client_config.max_concurrency, cache_loader);
 
     } catch (const std::exception& e) {
         LOG(ERROR) << "Failed to initialize Azure client: " << e.what();

--- a/docs/src/env-vars.md
+++ b/docs/src/env-vars.md
@@ -112,6 +112,24 @@ String
 
 None
 
+### RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_ENABLED
+
+> **Experimental** — This feature is under active development and may change in future releases.
+
+Controls whether the Azure Blob cache provider is enabled. When a compatible cache provider package (e.g., `tachyon-client`) is installed alongside `runai-model-streamer`, the streamer auto-discovers and loads it at runtime to accelerate model loading from Azure Blob Storage via a distributed cache.
+
+Set to `false` to disable the cache provider entirely, even if the package is installed. This is the recommended way to disable caching in case of issues.
+
+See [Azure Blob Cache Provider (Experimental)](usage.md#azure-blob-cache-provider-experimental) in the usage guide for details.
+
+#### Values accepted
+
+`true`, `false`, `0`, `1`
+
+#### Default value
+
+Unset — cache is auto-enabled when a compatible cache provider package is installed
+
 ### RUNAI_STREAMER_DIST
 
 Enables distributed streaming for multiple devices

--- a/docs/src/env-vars.md
+++ b/docs/src/env-vars.md
@@ -118,13 +118,13 @@ None
 
 Controls whether the Azure Blob cache provider is enabled. When a compatible cache provider package (e.g., `tachyon-client`) is installed alongside `runai-model-streamer`, the streamer auto-discovers and loads it at runtime to accelerate model loading from Azure Blob Storage via a distributed cache.
 
-Set to `false` to disable the cache provider entirely, even if the package is installed. This is the recommended way to disable caching in case of issues.
+Set to `0` to disable the cache provider entirely, even if the package is installed. This is the recommended way to disable caching in case of issues.
 
 See [Azure Blob Cache Provider (Experimental)](usage.md#azure-blob-cache-provider-experimental) in the usage guide for details.
 
 #### Values accepted
 
-`true`, `false`, `0`, `1`
+`0`, `1`, `auto`
 
 #### Default value
 

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -188,6 +188,72 @@ export AZURE_STORAGE_ACCOUNT_NAME="myaccount"
 # No additional configuration needed - managed identity is detected automatically
 ```
 
+##### Azure Blob Cache Provider (Experimental)
+
+> **Experimental** — This feature is under active development and may change in future releases.
+
+The streamer supports pluggable cache providers for Azure Blob Storage. When a compatible cache provider package is installed (e.g., `tachyon-client`), it is auto-discovered and loaded at runtime. All blob reads are then routed through the cache provider instead of the Azure SDK, enabling integration with distributed caches to accelerate model loading.
+
+###### How it works
+
+1. Install the cache provider package alongside `runai-model-streamer` (e.g., `pip install tachyon-client`)
+2. At startup, the streamer auto-discovers the cache library in Python site-packages via `dladdr`
+3. The library is loaded via `dlopen` and the `blob_read` symbol is resolved
+4. All subsequent Azure blob reads are served through the cache provider
+5. If no cache provider is installed, reads go directly to Azure Blob Storage — no regression
+
+###### Disabling the cache
+
+To disable the cache provider even when it is installed, set:
+
+```bash
+export RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_ENABLED=false
+```
+
+This is the recommended way to disable caching in case of issues.
+
+###### Implementing a cache provider
+
+A cache provider is a shared library that exports a single C function:
+
+```c
+#include <stddef.h>
+#include <sys/types.h>
+
+extern "C" ssize_t blob_read(
+    const char* account,      /* Azure Storage account name */
+    const char* container,    /* Azure container name */
+    const char* blob,         /* Blob path within the container */
+    void* buf,                /* Output buffer (caller-allocated) */
+    size_t offset,            /* Byte offset within the blob */
+    size_t length,            /* Number of bytes to read */
+    char** error_string       /* On error: set to malloc'd message; caller frees */
+);
+```
+
+**Return value:** Number of bytes read on success (should equal `length`), or `-1` on error.
+
+The cache provider has full control over how data is served and cached. The cache provider is responsible for serving data and managing its own cache lifecycle. How data is cached, populated, and evicted is entirely up to the cache provider implementation.
+
+The full API contract is defined in [`cpp/azure/azcache_provider/runai_azcache_provider.h`](../cpp/azure/azcache_provider/runai_azcache_provider.h). A test reference implementation is available at [`cpp/azure/azcache_provider/simple_file_cache_test.cc`](../cpp/azure/azcache_provider/simple_file_cache_test.cc).
+
+###### Debugging
+
+Enable debug logging to verify the cache provider is loaded and serving reads:
+
+```bash
+export RUNAI_STREAMER_LOG_TO_STDERR=1
+export RUNAI_STREAMER_LOG_LEVEL=DEBUG
+```
+
+You should see:
+```text
+AzCacheProvider: auto-discovered cache library: /path/to/site-packages/py_tachyon_client/libStorageDirect.so
+AzCacheProvider: cache provider loaded successfully from /path/to/...
+```
+
+If the library is not found or fails to load, the streamer falls back to direct Azure Blob Storage access.
+
 #### Streaming from Google cloud storage
 
 ##### SDK Authentication

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -207,7 +207,7 @@ The streamer supports pluggable cache providers for Azure Blob Storage. When a c
 To disable the cache provider even when it is installed, set:
 
 ```bash
-export RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_ENABLED=false
+export RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_ENABLED=0
 ```
 
 This is the recommended way to disable caching in case of issues.

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -224,10 +224,11 @@ extern "C" ssize_t blob_read(
     const char* account,      /* Azure Storage account name */
     const char* container,    /* Azure container name */
     const char* blob,         /* Blob path within the container */
-    void* buf,                /* Output buffer (caller-allocated) */
+    void* buf,                /* Output buffer (caller-allocated, >= length bytes) */
     size_t offset,            /* Byte offset within the blob */
     size_t length,            /* Number of bytes to read */
-    char** error_string       /* On error: set to malloc'd message; caller frees */
+    char* error_buf,          /* Caller-owned buffer for NUL-terminated error message */
+    size_t error_buf_size     /* Size of error_buf in bytes */
 );
 ```
 

--- a/tests/azure/test_azurecache.py
+++ b/tests/azure/test_azurecache.py
@@ -1,0 +1,188 @@
+"""
+End-to-end pytest for the azure cache provider (azcache_provider).
+
+Tests:
+  1. Compiles simple_file_cache_test.cc into a shared library
+  2. Creates a synthetic safetensors model and populates a cache directory
+  3. Streams the model through RunAI using the compiled cache .so
+  4. Verifies every tensor matches the original data
+
+Run:
+    pytest tests/azure/test_azurecache.py -v
+"""
+
+import json
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+
+import numpy as np
+import pytest
+
+
+SIMPLE_FILE_CACHE_SRC = os.path.join(
+    os.path.dirname(__file__), "..", "..", "cpp", "azure", "azcache_provider", "simple_file_cache_test.cc"
+)
+
+DTYPE_MAP = {
+    np.dtype("float32"): "F32",
+    np.dtype("float64"): "F64",
+    np.dtype("float16"): "F16",
+    np.dtype("int32"):   "I32",
+    np.dtype("int64"):   "I64",
+    np.dtype("uint8"):   "U8",
+}
+
+
+def create_safetensors_file(path, tensors):
+    """Create a safetensors file from a dict of {name: numpy_array}."""
+    header = {}
+    data_chunks = []
+    offset = 0
+    for name, arr in tensors.items():
+        nbytes = arr.nbytes
+        header[name] = {
+            "dtype": DTYPE_MAP[arr.dtype],
+            "shape": list(arr.shape),
+            "data_offsets": [offset, offset + nbytes],
+        }
+        data_chunks.append(arr.tobytes())
+        offset += nbytes
+
+    header_json = json.dumps(header).encode("utf-8")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(header_json)))
+        f.write(header_json)
+        for chunk in data_chunks:
+            f.write(chunk)
+    return offset
+
+
+@pytest.fixture(scope="module")
+def cache_lib():
+    """Compile simple_file_cache_test.cc into a shared library."""
+    src = os.path.abspath(SIMPLE_FILE_CACHE_SRC)
+    if not os.path.isfile(src):
+        pytest.skip(f"simple_file_cache_test.cc not found at {src}")
+
+    so_path = os.path.join(tempfile.gettempdir(), "libsimple_file_cache_test.so")
+    result = subprocess.run(
+        ["g++", "-shared", "-fPIC", "-o", so_path, src],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"Failed to compile simple_file_cache_test.cc:\n{result.stderr}")
+
+    yield so_path
+
+    if os.path.exists(so_path):
+        os.remove(so_path)
+
+
+@pytest.fixture(scope="module")
+def model_tensors():
+    """Create synthetic model tensors."""
+    return {
+        "model.embed_tokens.weight":              np.random.randn(512, 64).astype(np.float32),
+        "model.layers.0.self_attn.q_proj.weight": np.random.randn(64, 64).astype(np.float32),
+        "model.layers.0.self_attn.k_proj.weight": np.random.randn(64, 64).astype(np.float32),
+        "model.layers.0.self_attn.v_proj.weight": np.random.randn(64, 64).astype(np.float32),
+        "model.layers.0.self_attn.o_proj.weight": np.random.randn(64, 64).astype(np.float32),
+        "model.layers.0.mlp.gate_proj.weight":    np.random.randn(256, 64).astype(np.float32),
+        "model.layers.0.mlp.up_proj.weight":      np.random.randn(256, 64).astype(np.float32),
+        "model.layers.0.mlp.down_proj.weight":    np.random.randn(64, 256).astype(np.float32),
+        "model.norm.weight":                      np.random.randn(64).astype(np.float32),
+        "lm_head.weight":                         np.random.randn(512, 64).astype(np.float32),
+    }
+
+
+@pytest.fixture(scope="module")
+def cache_dir(model_tensors):
+    """Populate a cache directory with the synthetic model."""
+    cache_root = tempfile.mkdtemp(prefix="runai_azcache_test_")
+    container = "test-models"
+    blob = "my-llm/model.safetensors"
+    cache_path = os.path.join(cache_root, container, blob)
+
+    create_safetensors_file(cache_path, model_tensors)
+
+    yield cache_root, container, blob
+
+    shutil.rmtree(cache_root)
+
+
+class TestAzureCache:
+    """Test the azure cache provider with RunAI Model Streamer."""
+
+    def test_stream_from_cache(self, cache_lib, cache_dir, model_tensors):
+        """Stream a safetensors model from a file-based cache and verify all tensors.
+
+        Runs in a subprocess because AzCacheProviderLoader is a process-wide
+        singleton — the env var must be set before the C++ library initializes.
+
+        Uses a dummy Azure account name since all reads are served from the
+        cache provider — no real Azure credentials are needed.
+        """
+        cache_root, container, blob = cache_dir
+
+        env = os.environ.copy()
+        env["RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_LIB"] = cache_lib
+        env["RUNAI_CACHE_DIR"] = cache_root
+        env["RUNAI_STREAMER_LOG_LEVEL"] = "DEBUG"
+        env["RUNAI_STREAMER_LOG_TO_STDERR"] = "1"
+        # Provide a dummy account so the Azure client initializes without
+        # real credentials — the cache provider intercepts all reads.
+        if not env.get("AZURE_STORAGE_ACCOUNT_NAME") and \
+           not env.get("AZURE_STORAGE_CONNECTION_STRING"):
+            env["AZURE_STORAGE_ACCOUNT_NAME"] = "dummycachetest"
+
+        # Write a small inline script that streams and verifies
+        script = f"""
+import os, sys, json, struct, numpy as np
+os.environ["RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_LIB"] = "{cache_lib}"
+os.environ["RUNAI_CACHE_DIR"] = "{cache_root}"
+from runai_model_streamer import SafetensorsStreamer
+
+uri = "az://{container}/{blob}"
+with SafetensorsStreamer() as streamer:
+    streamer.stream_file(uri)
+    count = 0
+    for name, tensor in streamer.get_tensors():
+        count += 1
+    print(f"OK {{count}} tensors")
+    assert count == {len(model_tensors)}, f"Expected {len(model_tensors)}, got {{count}}"
+"""
+        # Run in a subprocess so RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_LIB is set before
+        # the C++ AzCacheProviderLoader singleton initializes. The singleton
+        # reads the env var once at construction and cannot be reconfigured.
+        # Other azure tests in this process may have already initialized it
+        # without the cache lib, permanently disabling it for this process.
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        if result.returncode != 0:
+            pytest.fail(
+                f"Cache streaming subprocess failed:\n"
+                f"STDOUT: {result.stdout}\n"
+                f"STDERR: {result.stderr}"
+            )
+
+        assert f"OK {len(model_tensors)} tensors" in result.stdout
+
+    def test_missing_cache_lib_falls_back(self, cache_dir, model_tensors):
+        """When cache lib is not set, the provider should not be enabled."""
+        os.environ.pop("RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_LIB", None)
+        assert not os.environ.get("RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_LIB")
+        # TODO: Full fallback verification requires a subprocess with Azure
+        # credentials to confirm reads go through Azure SDK when env var is unset.
+        # The singleton design prevents in-process reconfiguration.

--- a/tests/azure/test_azurecache.py
+++ b/tests/azure/test_azurecache.py
@@ -1,0 +1,185 @@
+"""
+End-to-end pytest for the azure cache provider (azcache_provider).
+
+Tests:
+  1. Compiles simple_file_cache.cc into a shared library
+  2. Creates a synthetic safetensors model and populates a cache directory
+  3. Streams the model through RunAI using the compiled cache .so
+  4. Verifies every tensor matches the original data
+
+Run:
+    pytest tests/azure/test_azurecache.py -v
+"""
+
+import json
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+
+import numpy as np
+import pytest
+
+
+SIMPLE_FILE_CACHE_SRC = os.path.join(
+    os.path.dirname(__file__), "..", "..", "cpp", "azure", "azcache_provider", "simple_file_cache.cc"
+)
+
+DTYPE_MAP = {
+    np.dtype("float32"): "F32",
+    np.dtype("float64"): "F64",
+    np.dtype("float16"): "F16",
+    np.dtype("int32"):   "I32",
+    np.dtype("int64"):   "I64",
+    np.dtype("uint8"):   "U8",
+}
+
+
+def create_safetensors_file(path, tensors):
+    """Create a safetensors file from a dict of {name: numpy_array}."""
+    header = {}
+    data_chunks = []
+    offset = 0
+    for name, arr in tensors.items():
+        nbytes = arr.nbytes
+        header[name] = {
+            "dtype": DTYPE_MAP[arr.dtype],
+            "shape": list(arr.shape),
+            "data_offsets": [offset, offset + nbytes],
+        }
+        data_chunks.append(arr.tobytes())
+        offset += nbytes
+
+    header_json = json.dumps(header).encode("utf-8")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(header_json)))
+        f.write(header_json)
+        for chunk in data_chunks:
+            f.write(chunk)
+    return offset
+
+
+@pytest.fixture(scope="module")
+def cache_lib():
+    """Compile simple_file_cache.cc into a shared library."""
+    src = os.path.abspath(SIMPLE_FILE_CACHE_SRC)
+    if not os.path.isfile(src):
+        pytest.skip(f"simple_file_cache.cc not found at {src}")
+
+    so_path = os.path.join(tempfile.gettempdir(), "libsimple_file_cache_test.so")
+    result = subprocess.run(
+        ["gcc", "-shared", "-fPIC", "-o", so_path, src],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"Failed to compile simple_file_cache.cc:\n{result.stderr}")
+
+    yield so_path
+
+    if os.path.exists(so_path):
+        os.remove(so_path)
+
+
+@pytest.fixture(scope="module")
+def model_tensors():
+    """Create synthetic model tensors."""
+    return {
+        "model.embed_tokens.weight":              np.random.randn(512, 64).astype(np.float32),
+        "model.layers.0.self_attn.q_proj.weight": np.random.randn(64, 64).astype(np.float32),
+        "model.layers.0.self_attn.k_proj.weight": np.random.randn(64, 64).astype(np.float32),
+        "model.layers.0.self_attn.v_proj.weight": np.random.randn(64, 64).astype(np.float32),
+        "model.layers.0.self_attn.o_proj.weight": np.random.randn(64, 64).astype(np.float32),
+        "model.layers.0.mlp.gate_proj.weight":    np.random.randn(256, 64).astype(np.float32),
+        "model.layers.0.mlp.up_proj.weight":      np.random.randn(256, 64).astype(np.float32),
+        "model.layers.0.mlp.down_proj.weight":    np.random.randn(64, 256).astype(np.float32),
+        "model.norm.weight":                      np.random.randn(64).astype(np.float32),
+        "lm_head.weight":                         np.random.randn(512, 64).astype(np.float32),
+    }
+
+
+@pytest.fixture(scope="module")
+def cache_dir(model_tensors):
+    """Populate a cache directory with the synthetic model."""
+    cache_root = tempfile.mkdtemp(prefix="runai_azcache_test_")
+    container = "test-models"
+    blob = "my-llm/model.safetensors"
+    cache_path = os.path.join(cache_root, container, blob)
+
+    create_safetensors_file(cache_path, model_tensors)
+
+    yield cache_root, container, blob
+
+    shutil.rmtree(cache_root)
+
+
+class TestAzureCache:
+    """Test the azure cache provider with RunAI Model Streamer."""
+
+    def test_stream_from_cache(self, cache_lib, cache_dir, model_tensors):
+        """Stream a safetensors model from a file-based cache and verify all tensors.
+
+        Runs in a subprocess because AzCacheProviderLoader is a process-wide
+        singleton — the env var must be set before the C++ library initializes.
+
+        Uses a dummy Azure account name since all reads are served from the
+        cache provider — no real Azure credentials are needed.
+        """
+        cache_root, container, blob = cache_dir
+
+        env = os.environ.copy()
+        env["RUNAI_STREAMER_AZURE_CACHE_LIB"] = cache_lib
+        env["RUNAI_CACHE_DIR"] = cache_root
+        env["RUNAI_STREAMER_LOG_LEVEL"] = "DEBUG"
+        env["RUNAI_STREAMER_LOG_TO_STDERR"] = "1"
+        # Provide a dummy account so the Azure client initializes without
+        # real credentials — the cache provider intercepts all reads.
+        if not env.get("AZURE_STORAGE_ACCOUNT_NAME") and \
+           not env.get("AZURE_STORAGE_CONNECTION_STRING"):
+            env["AZURE_STORAGE_ACCOUNT_NAME"] = "dummycachetest"
+
+        # Write a small inline script that streams and verifies
+        script = f"""
+import os, sys, json, struct, numpy as np
+os.environ["RUNAI_STREAMER_AZURE_CACHE_LIB"] = "{cache_lib}"
+os.environ["RUNAI_CACHE_DIR"] = "{cache_root}"
+from runai_model_streamer import SafetensorsStreamer
+
+uri = "az://{container}/{blob}"
+with SafetensorsStreamer() as streamer:
+    streamer.stream_file(uri)
+    count = 0
+    for name, tensor in streamer.get_tensors():
+        count += 1
+    print(f"OK {{count}} tensors")
+    assert count == {len(model_tensors)}, f"Expected {len(model_tensors)}, got {{count}}"
+"""
+        # Run in a subprocess so RUNAI_STREAMER_AZURE_CACHE_LIB is set before
+        # the C++ AzCacheProviderLoader singleton initializes. The singleton
+        # reads the env var once at construction and cannot be reconfigured.
+        # Other azure tests in this process may have already initialized it
+        # without the cache lib, permanently disabling it for this process.
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        if result.returncode != 0:
+            pytest.fail(
+                f"Cache streaming subprocess failed:\n"
+                f"STDOUT: {result.stdout}\n"
+                f"STDERR: {result.stderr}"
+            )
+
+        assert f"OK {len(model_tensors)} tensors" in result.stdout
+
+    def test_missing_cache_lib_falls_back(self, cache_dir, model_tensors):
+        """When cache lib is not set, the provider should not be enabled."""
+        os.environ.pop("RUNAI_STREAMER_AZURE_CACHE_LIB", None)
+        assert not os.environ.get("RUNAI_STREAMER_AZURE_CACHE_LIB")

--- a/tests/azure/test_azurecache.py
+++ b/tests/azure/test_azurecache.py
@@ -122,12 +122,9 @@ class TestAzureCache:
     def test_stream_from_cache(self, cache_lib, cache_dir, model_tensors):
         """Stream a safetensors model from a file-based cache and verify all tensors.
 
-        Runs in a subprocess because AzCacheProviderLoader is a process-wide
-        singleton — the env var must be set before the C++ library initializes.
-
-        Uses a dummy Azure account name since all reads are served from the
-        cache provider — no real Azure credentials are needed.
-        """
+        Runs in a subprocess because AzCacheProviderLoader is created per-AzureClient
+        and the ClientMgr pool reuses clients — env vars are read at first client
+        creation and cannot be changed for a reused client within the same process."""
         cache_root, container, blob = cache_dir
 
         env = os.environ.copy()
@@ -157,11 +154,9 @@ with SafetensorsStreamer() as streamer:
     print(f"OK {{count}} tensors")
     assert count == {len(model_tensors)}, f"Expected {len(model_tensors)}, got {{count}}"
 """
-        # Run in a subprocess so RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_LIB is set before
-        # the C++ AzCacheProviderLoader singleton initializes. The singleton
-        # reads the env var once at construction and cannot be reconfigured.
-        # Other azure tests in this process may have already initialized it
-        # without the cache lib, permanently disabling it for this process.
+        # Run in a subprocess because the ClientMgr pool reuses AzureClient instances
+        # along with their AzCacheProviderLoader — env vars are captured at first client
+        # creation and a pooled client won't pick up new env var values.
         result = subprocess.run(
             [sys.executable, "-c", script],
             env=env,
@@ -185,4 +180,5 @@ with SafetensorsStreamer() as streamer:
         assert not os.environ.get("RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_LIB")
         # TODO: Full fallback verification requires a subprocess with Azure
         # credentials to confirm reads go through Azure SDK when env var is unset.
-        # The singleton design prevents in-process reconfiguration.
+        # ClientMgr pools clients, so env var changes within the same process
+        # won't affect already-created clients.


### PR DESCRIPTION
## Pluggable Azure Blob Cache Provider with Auto-Discovery

Adds a pluggable cache provider for Azure Blob Storage reads with **zero-config auto-discovery**. When a compatible cache provider package (e.g., `tachyon-client`) is installed alongside `runai-model-streamer`, the streamer automatically discovers and loads it at runtime — no environment variable configuration needed.

### How it works

1. Cache provider package installs a shared library (e.g., `libStorageDirect.so`) into Python site-packages
2. At startup, the streamer auto-discovers the library via `dladdr` (walking from the runai .so location)
3. The library is loaded via `dlopen` and the `blob_read` symbol is resolved
4. All subsequent Azure blob reads are served through the cache provider
5. If no cache provider is installed, reads go directly to Azure Blob Storage — no regression

### Components

- **`runai_azcache_provider.h`**: C API contract (`blob_read`) for cache provider .so plugins
- **`azcache_provider_loader.cc`**: Singleton that auto-discovers via `dladdr`, falls back to `dlopen`/`dlsym`
- **`AsyncAzureClient` integration**: Routes reads through cache when provider is discovered
- **`simple_file_cache_test.cc`**: Example cache implementation for reference and unit testing
- **`RUNAI_STREAMER_EXPERIMENTAL_AZURE_CACHE_ENABLED`**: Disable switch to turn off cache even when provider is installed
- **Documentation**: `env-vars.md` and `usage.md` updated with auto-discovery flow and cache provider authoring guide

### Testing

- C++ unit tests: provider loading, error handling, fallback behavior
- Python e2e test: validates cache intercept with simple file-based provider
- AKS validated: cold cache and warm cache


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Experimental pluggable Azure Blob cache provider: runtime-loadable provider redirects blob reads; clients can query if cache is enabled and async downloads use a single request when caching is active.
  * Build support added to package the provider and test helper as shared libraries.

* **Documentation**
  * Added env-var reference, usage guide, and debugging instructions for the experimental cache provider.

* **Tests**
  * Added unit and end-to-end tests covering reads, errors, security checks, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->