### PR TITLE
s3: follow HTTP 3xx redirects in S3Crt client

### DIFF
--- a/cpp/s3/client_configuration/client_configuration.cc
+++ b/cpp/s3/client_configuration/client_configuration.cc
@@ -1,5 +1,7 @@
 #include "s3/client_configuration/client_configuration.h"
 
+#include <aws/core/client/ClientConfiguration.h>
+
 #include "utils/logging/logging.h"
 #include "utils/env/env.h"
 
@@ -8,6 +10,9 @@ namespace runai::llm::streamer::impl::s3
 
 ClientConfiguration::ClientConfiguration()
 {
+    // Follow HTTP 3xx redirects (e.g., 307 from Alluxio S3 Gateway).
+    config.followRedirects = Aws::Client::FollowRedirectsPolicy::ALWAYS;
+
     unsigned long max_connections = utils::getenv<unsigned long>("RUNAI_STREAMER_S3_MAX_CONNECTIONS", 0);
     if (max_connections)
     {


### PR DESCRIPTION
Alluxio S3 Gateway returns 307 redirects to internal workers for range reads. Set followRedirects = ALWAYS on the S3Crt ClientConfiguration so the underlying HTTP client follows the redirect instead of failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The S3 client now properly follows HTTP 3xx redirects (e.g., 307 responses).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->