### PR TITLE
feat: cache devcontainer image in ghcr.io to skip rebuilds on CI

### DIFF
--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -1,0 +1,34 @@
+name: Build and Push DevContainer
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.devcontainer/**'
+  workflow_dispatch:
+
+jobs:
+  build-devcontainer:
+    name: Build & Push DevContainer Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push devcontainer image
+      uses: devcontainers/ci@v0.3
+      with:
+        imageName: ghcr.io/run-ai/runai-model-streamer/devcontainer
+        cacheFrom: ghcr.io/run-ai/runai-model-streamer/devcontainer
+        push: always

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -11,7 +11,7 @@ jobs:
       packages: read
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v3

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -6,9 +6,19 @@ jobs:
   lifecycle-install-tests:
     name: Test, Build & Push
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set PACKAGE_VERSION
       run: echo "PACKAGE_VERSION=0.0.0+dev.$(git rev-parse --short HEAD)" >> $GITHUB_ENV
@@ -16,6 +26,9 @@ jobs:
     - name: Run tests and build
       uses: devcontainers/ci@v0.3
       with:
+        imageName: ghcr.io/run-ai/runai-model-streamer/devcontainer
+        cacheFrom: ghcr.io/run-ai/runai-model-streamer/devcontainer
+        push: never
         runCmd: |
           make test && \
           PACKAGE_VERSION=${{ env.PACKAGE_VERSION }} make build

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
+      packages: read
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v3

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -9,9 +9,19 @@ jobs:
   build-and-push:
     name: Build & Push
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set PACKAGE_VERSION
       run: echo "PACKAGE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
@@ -19,7 +29,9 @@ jobs:
     - name: Build package
       uses: devcontainers/ci@v0.3
       with:
-        push: always
+        imageName: ghcr.io/run-ai/runai-model-streamer/devcontainer
+        cacheFrom: ghcr.io/run-ai/runai-model-streamer/devcontainer
+        push: never
         runCmd: |
           PACKAGE_VERSION=${{ env.PACKAGE_VERSION }} make build
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/build-devcontainer.yml` — a dedicated workflow that builds and pushes the devcontainer image to `ghcr.io/run-ai/runai-model-streamer/devcontainer` only when `.devcontainer/**` changes (or triggered manually via `workflow_dispatch`)
- Updates `on-pr.yaml` and `on-release.yaml` to login to GHCR and use `cacheFrom: ghcr.io/run-ai/runai-model-streamer/devcontainer`, so Docker pulls cached layers instead of rebuilding from scratch every run
- PR and release workflows set `push: never` — image lifecycle is owned by the dedicated workflow

## Test plan

- [ ] Manually trigger `Build and Push DevContainer` workflow via `workflow_dispatch` after merge to populate the initial cache
- [ ] Open a follow-up PR and verify the devcontainer step pulls cached layers (significantly faster build time)
- [ ] Modify `.devcontainer/Dockerfile` in a PR and confirm `build-devcontainer.yml` triggers and pushes a new image

> **Note:** The first run requires a manual trigger since this PR doesn't touch `.devcontainer/` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
* Automated building and publishing of development container images when devcontainer configuration changes.
* CI updates to authenticate with the container registry for improved image handling.
* Enabled layer caching to speed up container builds and reduce redundant work.
* Upgraded checkout and tightened workflow permissions for more reliable and secure CI runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->