### PR TITLE
Implement GCS gRPC client behind env variable

### DIFF
--- a/cpp/gcs/client/async_gcs_client/BUILD
+++ b/cpp/gcs/client/async_gcs_client/BUILD
@@ -4,6 +4,7 @@ runai_cc_auto_library(
     name = "async_gcs_client",
     deps = [
         "@google_cloud_cpp//:storage",
+        "@google_cloud_cpp//:storage_grpc",
         "//utils/threadpool",
     ],
 )

--- a/cpp/gcs/client/async_gcs_client/async_gcs_client.cc
+++ b/cpp/gcs/client/async_gcs_client/async_gcs_client.cc
@@ -3,6 +3,7 @@
 #include <utility>
 
 #include "gcs/client/async_gcs_client/async_gcs_client.h"
+#include "google/cloud/storage/grpc_plugin.h"
 
 namespace runai::llm::streamer::impl::gcs
 {
@@ -12,13 +13,22 @@ void ReadObjectTask::execute() {
     promise.set_value(std::move(stream));
 }
 
-AsyncGcsClient::AsyncGcsClient(google::cloud::Options opts, unsigned int max_pool_size) :
+AsyncGcsClient::AsyncGcsClient(google::cloud::Options opts, unsigned int max_pool_size, bool use_grpc) :
     _pool([&](ReadObjectTask&& task, std::atomic<bool> & stopped)
         {
             task.execute();
         }, max_pool_size)
 {
-    _client = std::make_unique<google::cloud::storage::Client>(opts);
+    if (use_grpc) {
+        LOG(INFO) << "GCS client initialized with gRPC transport. "
+                << "Make sure you use this with direct connectivity for best performance; "
+                << "otherwise, it is recommended to not enable the gRPC client.";
+        _client = std::make_unique<google::cloud::storage::Client>(
+            google::cloud::storage::MakeGrpcClient(std::move(opts)));
+    } else {
+        LOG(DEBUG) << "GCS client initialized with default HTTP/JSON transport.";
+        _client = std::make_unique<google::cloud::storage::Client>(std::move(opts));
+    }
 }
 
 // Implementation of the private helper function.

--- a/cpp/gcs/client/async_gcs_client/async_gcs_client.h
+++ b/cpp/gcs/client/async_gcs_client/async_gcs_client.h
@@ -35,7 +35,7 @@ static ReadObjectFn createReadObjectFn(google::cloud::storage::Client * client, 
 struct AsyncGcsClient
 {
 public:
-    AsyncGcsClient(google::cloud::Options opts, unsigned max_pool_size);
+    AsyncGcsClient(google::cloud::Options options, unsigned int max_concurrency, bool use_grpc = false);
 
     template<typename... Options>
     google::cloud::future<google::cloud::storage::ObjectReadStream> ReadObjectAsync(

--- a/cpp/gcs/client/client.cc
+++ b/cpp/gcs/client/client.cc
@@ -29,7 +29,11 @@ GCSClient::GCSClient(const common::backend_api::ObjectClientConfig_t& config) :
     _responder(nullptr),
     _chunk_bytesize(config.default_storage_chunk_size)
 {
-    _client = std::make_unique<AsyncGcsClient>(_client_config.options, _client_config.max_concurrency);
+    _client = std::make_unique<AsyncGcsClient>(
+        _client_config.options, 
+        _client_config.max_concurrency,
+        _client_config.use_grpc
+    );
 }
 
 bool GCSClient::verify_credentials(const common::backend_api::ObjectClientConfig_t & config) const

--- a/cpp/gcs/client_configuration/BUILD
+++ b/cpp/gcs/client_configuration/BUILD
@@ -4,6 +4,7 @@ runai_cc_auto_library(
     name = "client_configuration",
     deps = [
         "@google_cloud_cpp//:storage",
+        "@google_cloud_cpp//:storage_grpc",
         "//common/exception",
         "//common/response_code",
         "//common/storage_uri",

--- a/cpp/gcs/client_configuration/client_configuration.cc
+++ b/cpp/gcs/client_configuration/client_configuration.cc
@@ -1,6 +1,7 @@
 #include "gcs/client_configuration/client_configuration.h"
 
 #include "google/cloud/storage/client.h"
+#include "google/cloud/storage/grpc_plugin.h"
 
 #include "common/exception/exception.h"
 #include "common/response_code/response_code.h"
@@ -16,6 +17,8 @@ namespace runai::llm::streamer::impl::gcs
 
 ClientConfiguration::ClientConfiguration()
 {
+    use_grpc = utils::getenv<bool>("RUNAI_STREAMER_GCS_USE_GRPC", false);
+
     const auto max_connections = utils::getenv<unsigned long>("RUNAI_STREAMER_S3_MAX_CONNECTIONS", 0);
     if (max_connections) {
         max_concurrency = max_connections;

--- a/cpp/gcs/client_configuration/client_configuration.h
+++ b/cpp/gcs/client_configuration/client_configuration.h
@@ -12,6 +12,7 @@ struct ClientConfiguration
     ClientConfiguration();
     google::cloud::Options options;
     unsigned max_concurrency;
+    bool use_grpc;
 };
 
 }; //namespace runai::llm::streamer::impl::gcs

--- a/docs/src/env-vars.md
+++ b/docs/src/env-vars.md
@@ -139,3 +139,18 @@ String `0` or `1`
 #### Default value
 
 `0`
+
+### RUNAI_STREAMER_GCS_USE_GRPC
+
+Enables the gRPC transport for the GCS client, which utilizes direct connectivity for higher throughput and lower latency when running within Google Cloud.
+
+If not defined (default) the GCS client uses the standard HTTP/JSON transport.
+
+#### Values accepted
+
+String `0` or `1`
+
+#### Default value
+
+`0`
+

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -194,7 +194,7 @@ export AZURE_STORAGE_ACCOUNT_NAME="myaccount"
 
 GCS SDK backend is provided through the Python package `runai-model-streamer-gcs`.
 
-To authentication to GCS, there are multiple configuration options:
+To authenticate to GCS, there are multiple configuration options:
 
 1. External Credentials: If you set the `RUNAI_STREAMER_GCS_CREDENTIAL_FILE` environment variable, the
    SDK will load credentials from a JSON file at the path specified (eg: service account credentials)
@@ -205,6 +205,25 @@ To authentication to GCS, there are multiple configuration options:
 
 See [How Application Default Credentials works](https://cloud.google.com/docs/authentication/application-default-credentials)
 for more information.
+
+###### Transport Configuration
+
+By default, the GCS SDK backend communicates using the standard HTTP/JSON transport. To achieve significantly higher throughput and lower latency when running within Google Cloud (e.g., GKE or GCE), you can use [gRPC to interact with Cloud Storage](https://docs.cloud.google.com/storage/docs/enable-grpc-api). gRPC utilizes [direct connectivity](https://docs.cloud.google.com/storage/docs/direct-connectivity) between Compute Engine instances and Cloud Storage buckets, bypassing [Google Front Ends (GFEs)](https://docs.cloud.google.com/docs/security/infrastructure/design#google-frontend-service).
+
+To enable the gRPC client, set the following environment variable (Note: this variable strictly requires a numeric boolean value):
+* `RUNAI_STREAMER_GCS_USE_GRPC`: Set this to `1` to enable the gRPC transport, or `0` (the default) to use HTTP/JSON.
+
+**Verifying DirectPath Connectivity:**
+If you enable gRPC, we highly recommend verifying that direct connectivity is successfully routing your traffic, as it is needed to achieve optimal performance. If direct connectivity is unavailable in your environment, it is best to leave `RUNAI_STREAMER_GCS_USE_GRPC` unset to fall back to the default transport for the best performance.
+
+You can verify your connection by enabling the gRPC core trace logs with the following environment variables:
+
+```bash
+export GRPC_VERBOSITY=DEBUG
+export GRPC_TRACE=client_channel,xds
+```
+
+In the resulting console output, you are looking for metric blocks related to actual file downloads (e.g. `google.storage.v2.Storage/ReadObject`). To know direct connectivity is set, you need to see the `grpc_target` field in those blocks explicitly targeting `google-c2p:///storage.googleapis.com`. If your actual file downloads are instead targeting standard `dns:///storage.googleapis.com` addresses, traffic is going through the standard public Cloud Load Balancers instead of the unproxied DirectPath route, and you should disable the gRPC client. (Note: You may still see `dns:///storage.googleapis.com` targets for background routing lookups like `RouteLookupService/RouteLookup`, which is perfectly normal as long as the `ReadObject` calls use `google-c2p:///`).
 
 ##### HMAC Authentication
 

--- a/examples/stream_safetensors_from_gcs.ipynb
+++ b/examples/stream_safetensors_from_gcs.ipynb
@@ -122,6 +122,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Transport Configuration (Optional)\n",
+    "By default, the GCS SDK communicates using the HTTP/JSON transport. To achieve significantly higher throughput when running within Google Cloud, you can enable the gRPC transport to utilize direct connectivity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Enable gRPC transport for higher throughput on GCP\n",
+    "# Note: This strictly requires the string \"1\" or \"0\"\n",
+    "os.environ['RUNAI_STREAMER_GCS_USE_GRPC'] = \"1\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Streaming\n",
     "\n",
     "To load the tensors from the Cloud Storage file we need to create `SafetensorsStreamer` instance, perform the request, and start getting the tensors:"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GCS client can use gRPC transport controlled by the RUNAI_STREAMER_GCS_USE_GRPC environment variable (off by default).

* **Improvements**
  * Updated storage client to enable gRPC-backed operations and related dependency support, improving transport flexibility and performance options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

* **Tested**
  * **Standalone Performance Benchmark**: Created a standalone Python script (benchmark.py) using SafetensorsStreamer to pull 35 shards of Qwen3-Coder-480B-A35B-Instruct-FP8 directly from GCS. Verified that setting RUNAI_STREAMER_GCS_USE_GRPC=1 successfully activated the gRPC transport. Furthermore, I enabled gRPC tracing and verified that the ReadObject requests successfully targeted the google-c2p:///storage.googleapis.com endpoint, confirming active DirectPath routing. Also tested with RUNAI_STREAMER_GCS_USE_GRPC=0 to test the default client. 
