### PR TITLE
chore: add support to use ManagedIdentityCredential when AZURE_CLIENT_ID env is specified

### DIFF
--- a/cpp/azure/client/client.cc
+++ b/cpp/azure/client/client.cc
@@ -27,6 +27,27 @@ namespace runai::llm::streamer::impl::azure
 
 constexpr char kAzureApplicationId[] = "azpartner-runai";
 
+// Thread-safe singleton providing shared DefaultAzureCredential instance.
+// All AzureClient instances share the same credential object and its token cache,
+// avoiding duplicate IMDS/Azure AD requests under concurrent load.
+// GetToken() is called once during initialization as a fail-fast mechanism to validate
+// the credential chain early (catches missing env vars, IMDS unavailable, etc.).
+std::shared_ptr<Azure::Identity::DefaultAzureCredential> GetSharedDefaultAzureCredential() {
+    static std::shared_ptr<Azure::Identity::DefaultAzureCredential> shared_credential;
+    static std::once_flag init_flag;
+    std::call_once(init_flag, []() {
+        auto cred = std::make_shared<Azure::Identity::DefaultAzureCredential>();
+        // Validate credential chain early via GetToken() as fail-fast mechanism.
+        Azure::Core::Credentials::TokenRequestContext token_ctx;
+        token_ctx.Scopes = {"https://storage.azure.com/.default"};
+        Azure::Core::Context ctx = Azure::Core::Context::ApplicationContext.WithDeadline(
+            std::chrono::system_clock::now() + std::chrono::seconds(5));
+        (void)cred->GetToken(token_ctx, ctx); // throws if credential chain fails
+        shared_credential = cred; // only assign if GetToken() succeeds
+    });
+    return shared_credential;
+}
+
 AzureClient::AzureClient(const common::backend_api::ObjectClientConfig_t& config) :
     _stop(false),
     _responder(nullptr),
@@ -110,16 +131,14 @@ AzureClient::AzureClient(const common::backend_api::ObjectClientConfig_t& config
                 std::string url = "https://" + _account_name.value() + ".blob.core.windows.net";
                 std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential;
 
-                // Try DefaultAzureCredential first, fall back to ManagedIdentityCredential
-                // with explicit client_id (through AZURE_CLIENT_ID env variable).
+                // Try DefaultAzureCredential first, fall back to ManagedIdentityCredential.
+                // NOTE: Uses a shared process-level DefaultAzureCredential singleton that calls
+                // GetToken() once during initialization (fail-fast validation). All clients share
+                // the same instance and its cached token, avoiding IMDS throttling under concurrent load.
+                // Subsequent clients reuse the validated shared instance and its token cache.
                 try {
                     LOG(DEBUG) << "Trying DefaultAzureCredential";
-                    auto default_cred = std::make_shared<Azure::Identity::DefaultAzureCredential>();
-                    Azure::Core::Credentials::TokenRequestContext token_ctx;
-                    token_ctx.Scopes = {"https://storage.azure.com/.default"};
-                    Azure::Core::Context ctx;
-                    (void)default_cred->GetToken(token_ctx, ctx); // force auth now
-                    credential = default_cred;
+                    credential = GetSharedDefaultAzureCredential();
                     LOG(DEBUG) << "Azure client initialized with DefaultAzureCredential for account: " << _account_name.value();
                 } catch (const std::exception& e) {
                     LOG(WARNING) << "DefaultAzureCredential failed: " << e.what();

--- a/cpp/azure/client/client.cc
+++ b/cpp/azure/client/client.cc
@@ -11,6 +11,7 @@
 
 #include <azure/storage/blobs.hpp>
 #include <azure/identity/default_azure_credential.hpp>
+#include <azure/identity/managed_identity_credential.hpp>
 #include <azure/storage/common/storage_credential.hpp>
 #include <azure/core/exception.hpp>
 
@@ -34,6 +35,7 @@ AzureClient::AzureClient(const common::backend_api::ObjectClientConfig_t& config
     // ClientConfiguration reads environment variables
     _account_name = _client_config.account_name;
     _account_key = _client_config.account_key;
+    _client_id = _client_config.client_id;
 #ifdef AZURITE_TESTING
     _connection_string = _client_config.connection_string;
 #endif
@@ -61,6 +63,10 @@ AzureClient::AzureClient(const common::backend_api::ObjectClientConfig_t& config
                 _connection_string = std::string(value);
             }
 #endif
+            else if (strcmp(key, "client_id") == 0)
+            {
+                _client_id = std::string(value);
+            }
             else
             {
                 LOG(WARNING) << "Unknown Azure parameter: " << key;
@@ -101,15 +107,32 @@ AzureClient::AzureClient(const common::backend_api::ObjectClientConfig_t& config
                 _blob_service_client = std::make_shared<BlobServiceClient>(url, credential, options);
                 LOG(DEBUG) << "Azure client initialized with StorageSharedKeyCredential for account: " << _account_name.value();
             } else {
-                // Use DefaultAzureCredential (managed identity, Azure CLI, environment variables, etc.)
-                // Reference: https://learn.microsoft.com/en-us/azure/developer/cpp/sdk/authentication
                 std::string url = "https://" + _account_name.value() + ".blob.core.windows.net";
-                // Share a single DefaultAzureCredential across all clients in the process to better
-                // utilize token caching and reduce chances of overwhelming authentication sources
-                // (e.g., IMDS) which can result in fatal throttling errors.
-                static auto credential = std::make_shared<Azure::Identity::DefaultAzureCredential>();
+                std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential;
+
+                // Try DefaultAzureCredential first, fall back to ManagedIdentityCredential
+                // with explicit client_id (through AZURE_CLIENT_ID env variable).
+                try {
+                    LOG(DEBUG) << "Trying DefaultAzureCredential";
+                    auto default_cred = std::make_shared<Azure::Identity::DefaultAzureCredential>();
+                    Azure::Core::Credentials::TokenRequestContext token_ctx;
+                    token_ctx.Scopes = {"https://storage.azure.com/.default"};
+                    Azure::Core::Context ctx;
+                    (void)default_cred->GetToken(token_ctx, ctx); // force auth now
+                    credential = default_cred;
+                    LOG(DEBUG) << "Azure client initialized with DefaultAzureCredential for account: " << _account_name.value();
+                } catch (const std::exception& e) {
+                    LOG(WARNING) << "DefaultAzureCredential failed: " << e.what();
+                    if (_client_id.has_value()) {
+                        LOG(DEBUG) << "Falling back to ManagedIdentityCredential";
+                        credential = std::make_shared<Azure::Identity::ManagedIdentityCredential>(_client_id.value());
+                        LOG(DEBUG) << "Azure client initialized with ManagedIdentityCredential for account: " << _account_name.value();
+                    } else {
+                        throw;
+                    }
+                }
                 _blob_service_client = std::make_shared<BlobServiceClient>(url, credential, options);
-                LOG(DEBUG) << "Azure client initialized with DefaultAzureCredential for account: " << _account_name.value();
+                LOG(DEBUG) << "Azure client initialized with token credential for account: " << _account_name.value();
             }
         } else {
 #ifdef AZURITE_TESTING
@@ -141,6 +164,7 @@ bool AzureClient::verify_credentials(const common::backend_api::ObjectClientConf
     ClientConfiguration temp_config;
     std::optional<std::string> temp_account_name = temp_config.account_name;
     std::optional<std::string> temp_account_key = temp_config.account_key;
+    std::optional<std::string> temp_client_id = temp_config.client_id;
 #ifdef AZURITE_TESTING
     std::optional<std::string> temp_connection_string = temp_config.connection_string;
 #endif
@@ -151,6 +175,7 @@ bool AzureClient::verify_credentials(const common::backend_api::ObjectClientConf
         for (size_t i = 0; i < config.num_initial_params; ++i, ++ptr) {
             if (strcmp(ptr->key, "account_name") == 0) temp_account_name = std::string(ptr->value);
             else if (strcmp(ptr->key, "account_key") == 0) temp_account_key = std::string(ptr->value);
+            else if (strcmp(ptr->key, "client_id") == 0) temp_client_id = std::string(ptr->value);
 #ifdef AZURITE_TESTING
             else if (strcmp(ptr->key, "connection_string") == 0) temp_connection_string = std::string(ptr->value);
 #endif
@@ -162,7 +187,9 @@ bool AzureClient::verify_credentials(const common::backend_api::ObjectClientConf
         return (_connection_string == temp_connection_string);
     }
 #endif
-    return (_account_name == temp_account_name) && (_account_key == temp_account_key);
+    return (_account_name == temp_account_name)
+        && (_account_key == temp_account_key)
+        && (_client_id == temp_client_id);
 }
 
 common::backend_api::Response AzureClient::async_read_response()

--- a/cpp/azure/client/client.h
+++ b/cpp/azure/client/client.h
@@ -47,6 +47,7 @@ struct AzureClient : common::IClient
     // Azure credentials
     std::optional<std::string> _account_name;
     std::optional<std::string> _account_key;
+    std::optional<std::string> _client_id;
 #ifdef AZURITE_TESTING
     std::optional<std::string> _connection_string;
 #endif

--- a/cpp/azure/client_configuration/client_configuration.cc
+++ b/cpp/azure/client_configuration/client_configuration.cc
@@ -29,16 +29,17 @@ ClientConfiguration::ClientConfiguration()
     }
 
     // Account name configuration from environment variable
-    // Authentication uses DefaultAzureCredential which supports:
-    // - Environment variables (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET)
-    // - Managed Identity
-    // - Azure CLI
-    // - Visual Studio Code
-    // Reference: https://learn.microsoft.com/en-us/azure/developer/cpp/sdk/authentication
     const auto acct_name = utils::getenv<std::string>("AZURE_STORAGE_ACCOUNT_NAME", "");
     if (!acct_name.empty()) {
         LOG(DEBUG) << "Azure Storage account name: " << acct_name;
         account_name = acct_name;
+    }
+
+    // Client ID used for fallback authentication when DefaultAzureCredential cannot authenticate.
+    const auto cid = utils::getenv<std::string>("AZURE_CLIENT_ID", "");
+    if (!cid.empty()) {
+        LOG(DEBUG) << "May be AZURE_CLIENT_ID for Managed Identity authentication as a fallback option";
+        client_id = cid;
     }
 
     unsigned nprocs = std::thread::hardware_concurrency();

--- a/cpp/azure/client_configuration/client_configuration.h
+++ b/cpp/azure/client_configuration/client_configuration.h
@@ -11,6 +11,8 @@ struct ClientConfiguration
     // Azure client configuration options
     std::optional<std::string> account_name;
     std::optional<std::string> account_key;
+    // Client ID for user-assigned managed identity
+    std::optional<std::string> client_id;
 #ifdef AZURITE_TESTING
     // Connection string is only available for Azurite/local testing
     std::optional<std::string> connection_string;


### PR DESCRIPTION
**What This PR Does**:
This PR add support to authenticate azure-blob-storage through ManagedIdentityCredential when AZURE_CLIENT_ID env is configured and DefaultAzureCredential is failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Managed Identity support for Azure Storage authentication with automatic fallback to a user-assigned identity when configured.
  * New configuration option to specify a client ID for user-assigned managed identities via environment variable or settings.

* **Bug Fixes**
  * Credential verification updated to include client ID for more accurate authentication validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/run-ai/runai-model-streamer/pull/146)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->