### PR TITLE
refactor: rename exported ABI symbol to cache_abi_version

### DIFF
--- a/cpp/azure/azcache_provider/azcache_provider_test.cc
+++ b/cpp/azure/azcache_provider/azcache_provider_test.cc
@@ -414,7 +414,7 @@ static std::string build_test_so(const std::string& source, const std::string& n
 
 TEST(CacheProviderLoaderAbiTest, AutoModeNoVersionSymbolDisables)
 {
-    // .so with blob_read but no runai_cache_abi_version
+    // .so with blob_read but no cache_abi_version
     std::string src = R"(
 #include <stddef.h>
 #include <sys/types.h>
@@ -437,7 +437,7 @@ ssize_t blob_read(const char* a, const char* c, const char* b,
 
 TEST(CacheProviderLoaderAbiTest, RequiredModeNoVersionSymbolThrows)
 {
-    // .so with blob_read but no runai_cache_abi_version
+    // .so with blob_read but no cache_abi_version
     std::string src = R"(
 #include <stddef.h>
 #include <sys/types.h>
@@ -464,7 +464,7 @@ TEST(CacheProviderLoaderAbiTest, AutoModeVersionMismatchDisables)
 #include <stddef.h>
 #include <stdint.h>
 #include <sys/types.h>
-uint32_t runai_cache_abi_version(void) { return 999; }
+uint32_t cache_abi_version(void) { return 999; }
 ssize_t blob_read(const char* a, const char* c, const char* b,
     void* buf, size_t offset, size_t length,
     char* err, size_t err_sz) { return (ssize_t)length; }
@@ -489,7 +489,7 @@ TEST(CacheProviderLoaderAbiTest, RequiredModeVersionMismatchThrows)
 #include <stddef.h>
 #include <stdint.h>
 #include <sys/types.h>
-uint32_t runai_cache_abi_version(void) { return 999; }
+uint32_t cache_abi_version(void) { return 999; }
 ssize_t blob_read(const char* a, const char* c, const char* b,
     void* buf, size_t offset, size_t length,
     char* err, size_t err_sz) { return (ssize_t)length; }
@@ -513,7 +513,7 @@ TEST(CacheProviderLoaderAbiTest, AutoModeVersionMatchEnables)
 #include <stddef.h>
 #include <stdint.h>
 #include <sys/types.h>
-uint32_t runai_cache_abi_version(void) { return 1; }
+uint32_t cache_abi_version(void) { return 1; }
 ssize_t blob_read(const char* a, const char* c, const char* b,
     void* buf, size_t offset, size_t length,
     char* err, size_t err_sz) { return (ssize_t)length; }
@@ -538,7 +538,7 @@ TEST(CacheProviderLoaderAbiTest, RequiredModeVersionMatchEnables)
 #include <stddef.h>
 #include <stdint.h>
 #include <sys/types.h>
-uint32_t runai_cache_abi_version(void) { return 1; }
+uint32_t cache_abi_version(void) { return 1; }
 ssize_t blob_read(const char* a, const char* c, const char* b,
     void* buf, size_t offset, size_t length,
     char* err, size_t err_sz) { return (ssize_t)length; }
@@ -561,7 +561,7 @@ TEST(CacheProviderLoaderAbiTest, AutoModeVersionMatchNoBlobReadDisables)
     // .so with correct version but no blob_read symbol
     std::string src = R"(
 #include <stdint.h>
-uint32_t runai_cache_abi_version(void) { return 1; }
+uint32_t cache_abi_version(void) { return 1; }
 )";
     std::string path = build_test_so(src, "no_blob_read");
     ASSERT_FALSE(path.empty());
@@ -581,7 +581,7 @@ TEST(CacheProviderLoaderAbiTest, RequiredModeVersionMatchNoBlobReadThrows)
     // .so with correct version but no blob_read symbol
     std::string src = R"(
 #include <stdint.h>
-uint32_t runai_cache_abi_version(void) { return 1; }
+uint32_t cache_abi_version(void) { return 1; }
 )";
     std::string path = build_test_so(src, "no_blob_read_req");
     ASSERT_FALSE(path.empty());

--- a/cpp/azure/azcache_provider/runai_azcache_provider.h
+++ b/cpp/azure/azcache_provider/runai_azcache_provider.h
@@ -22,7 +22,7 @@
  *
  *   #include "runai_azcache_provider.h"
  *
- *   extern "C" uint32_t runai_cache_abi_version(void) {
+ *   extern "C" uint32_t cache_abi_version(void) {
  *       return RUNAI_CACHE_ABI_VERSION;
  *   }
  *
@@ -117,12 +117,12 @@ typedef void (*shutdown_fn)(void);
 /*
  * ABI versioning — guards against incompatible .so after interface changes.
  *
- * The cache provider .so must export runai_cache_abi_version() returning
+ * The cache provider .so must export cache_abi_version() returning
  * RUNAI_CACHE_ABI_VERSION. The loader rejects libraries that do not export
  * the symbol or return an unsupported version.
  */
 #define RUNAI_CACHE_ABI_VERSION 1
-#define RUNAI_CACHE_ABI_VERSION_SYMBOL "runai_cache_abi_version"
+#define RUNAI_CACHE_ABI_VERSION_SYMBOL "cache_abi_version"
 
 typedef uint32_t (*runai_cache_abi_version_fn)(void);
 

--- a/cpp/azure/azcache_provider/simple_file_cache_test.cc
+++ b/cpp/azure/azcache_provider/simple_file_cache_test.cc
@@ -78,7 +78,7 @@ extern "C" {
 #endif
 
 __attribute__((visibility("default")))
-uint32_t runai_cache_abi_version(void)
+uint32_t cache_abi_version(void)
 {
     return 1;
 }


### PR DESCRIPTION
Keep the symbol name common

Only the exported symbol name changes (runai_cache_abi_version → cache_abi_version). Internal macros and typedefs remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the cache provider library's internal versioning interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/run-ai/runai-model-streamer/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->