### PR TITLE
Filter out HNS directories from listing 

### DIFF
--- a/py/runai_model_streamer_azure/runai_model_streamer_azure/files/files.py
+++ b/py/runai_model_streamer_azure/runai_model_streamer_azure/files/files.py
@@ -6,7 +6,7 @@ import os
 import posixpath
 from pathlib import Path
 
-from azure.storage.blob import BlobServiceClient
+from azure.storage.blob import BlobServiceClient, BlobProperties
 
 
 # Application ID for telemetry (prepended to User-Agent)
@@ -173,18 +173,21 @@ def list_files(
     paths = []
     if recursive:
         # Recursive: list all blobs under the prefix
-        blob_items = container_client.list_blobs(name_starts_with=prefix)
+        blob_items = container_client.list_blobs(name_starts_with=prefix, include=["metadata"])
         for item in blob_items:
-            if hasattr(item, 'name'):
+            if hasattr(item, 'name') and not item.name.endswith('/') and not _is_adls_directory(item):
                 paths.append(item.name)
     else:
         # Non-recursive: use walk_blobs with delimiter to only get blobs at this level
         # This is more efficient as Azure service handles the filtering
-        blob_items = container_client.walk_blobs(name_starts_with=prefix, delimiter='/')
+        blob_items = container_client.walk_blobs(name_starts_with=prefix, delimiter='/', include=["metadata"])
         for item in blob_items:
             # walk_blobs returns BlobProperties for blobs and BlobPrefix for directories
             # We only want blobs (files), not prefixes (directories)
-            if hasattr(item, 'name') and not item.name.endswith('/'):
+
+            # When listing against ADLS we might encounter directories thatdo not have a trailing slash 
+            # So, we use metadata to filter them out
+            if hasattr(item, 'name') and not item.name.endswith('/') and not _is_adls_directory(item):
                 paths.append(item.name)
 
     # Filter out directories (blobs ending with /)
@@ -218,3 +221,15 @@ def removeprefix(s: str, prefix: str) -> str:
     if s.startswith(prefix):
         return s[len(prefix):]
     return s
+
+def _is_adls_directory(self, blob: BlobProperties) -> bool:
+        # Directory stubs in HNS accounts are zero-byte blobs with hdi_isfolder=true metadata 
+        metadata = getattr(blob, "metadata", None) 
+        if metadata is not None: 
+            if blob.size == 0 and str(blob.metadata.get("hdi_isfolder")).lower() == "true":
+                return True 
+            
+            # Handle capitalized case 
+            if blob.size == 0 and str(blob.metadata.get("Hdi_isfolder")).lower() == "true":
+                return True
+        return False

--- a/py/runai_model_streamer_azure/runai_model_streamer_azure/files/files.py
+++ b/py/runai_model_streamer_azure/runai_model_streamer_azure/files/files.py
@@ -228,8 +228,4 @@ def _is_adls_directory(blob: BlobProperties) -> bool:
         if metadata is not None and blob.size == 0: 
             if blob.size == 0 and str(metadata.get("hdi_isfolder")).lower() == "true":
                 return True 
-            
-            # Handle capitalized case 
-            if blob.size == 0 and str(metadata.get("Hdi_isfolder")).lower() == "true":
-                return True
         return False

--- a/py/runai_model_streamer_azure/runai_model_streamer_azure/files/files.py
+++ b/py/runai_model_streamer_azure/runai_model_streamer_azure/files/files.py
@@ -224,9 +224,9 @@ def _is_adls_directory(blob: BlobProperties) -> bool:
     # When listing against ADLS, we might hit directory stubs (hdi_isfolder=true) that don't have a trailing slash
     # So, we use metadata to filter them out
     return (
-    blob.size == 0
-    and blob.metadata is not None
-    and (blob.metadata.get("hdi_isfolder") == "true" or
-         blob.metadata.get("Hdi_isfolder") == "true" # Sometimes, the service returns this metadata key capitalized 
-        )
+        blob.size == 0
+        and blob.metadata is not None
+        and (blob.metadata.get("hdi_isfolder") == "true" 
+            or blob.metadata.get("Hdi_isfolder") == "true" # Sometimes, the service returns this metadata key capitalized 
+            )
     )

--- a/py/runai_model_streamer_azure/runai_model_streamer_azure/files/files.py
+++ b/py/runai_model_streamer_azure/runai_model_streamer_azure/files/files.py
@@ -185,7 +185,7 @@ def list_files(
             # walk_blobs returns BlobProperties for blobs and BlobPrefix for directories
             # We only want blobs (files), not prefixes (directories)
 
-            # When listing against ADLS we might encounter directories thatdo not have a trailing slash 
+            # When listing against ADLS, we might encounter directories that don't have a trailing slash 
             # So, we use metadata to filter them out
             if hasattr(item, 'name') and not item.name.endswith('/') and not _is_adls_directory(item):
                 paths.append(item.name)
@@ -222,14 +222,14 @@ def removeprefix(s: str, prefix: str) -> str:
         return s[len(prefix):]
     return s
 
-def _is_adls_directory(self, blob: BlobProperties) -> bool:
+def _is_adls_directory(blob: BlobProperties) -> bool:
         # Directory stubs in HNS accounts are zero-byte blobs with hdi_isfolder=true metadata 
         metadata = getattr(blob, "metadata", None) 
-        if metadata is not None: 
-            if blob.size == 0 and str(blob.metadata.get("hdi_isfolder")).lower() == "true":
+        if metadata is not None and blob.size == 0: 
+            if blob.size == 0 and str(metadata.get("hdi_isfolder")).lower() == "true":
                 return True 
             
             # Handle capitalized case 
-            if blob.size == 0 and str(blob.metadata.get("Hdi_isfolder")).lower() == "true":
+            if blob.size == 0 and str(metadata.get("Hdi_isfolder")).lower() == "true":
                 return True
         return False

--- a/py/runai_model_streamer_azure/runai_model_streamer_azure/files/files.py
+++ b/py/runai_model_streamer_azure/runai_model_streamer_azure/files/files.py
@@ -175,7 +175,7 @@ def list_files(
         # Recursive: list all blobs under the prefix
         blob_items = container_client.list_blobs(name_starts_with=prefix, include=["metadata"])
         for item in blob_items:
-            if hasattr(item, 'name') and not item.name.endswith('/') and not _is_adls_directory(item):
+            if hasattr(item, 'name') and not _is_adls_directory(item):
                 paths.append(item.name)
     else:
         # Non-recursive: use walk_blobs with delimiter to only get blobs at this level
@@ -185,8 +185,6 @@ def list_files(
             # walk_blobs returns BlobProperties for blobs and BlobPrefix for directories
             # We only want blobs (files), not prefixes (directories)
 
-            # When listing against ADLS, we might encounter directories that don't have a trailing slash 
-            # So, we use metadata to filter them out
             if hasattr(item, 'name') and not item.name.endswith('/') and not _is_adls_directory(item):
                 paths.append(item.name)
 
@@ -223,9 +221,12 @@ def removeprefix(s: str, prefix: str) -> str:
     return s
 
 def _is_adls_directory(blob: BlobProperties) -> bool:
-        # Directory stubs in HNS accounts are zero-byte blobs with hdi_isfolder=true metadata 
-        metadata = getattr(blob, "metadata", None) 
-        if metadata is not None and blob.size == 0: 
-            if blob.size == 0 and str(metadata.get("hdi_isfolder")).lower() == "true":
-                return True 
-        return False
+    # When listing against ADLS, we might hit directory stubs (hdi_isfolder=true) that don't have a trailing slash
+    # So, we use metadata to filter them out
+    return (
+    blob.size == 0
+    and blob.metadata is not None
+    and (blob.metadata.get("hdi_isfolder") == "true" or
+         blob.metadata.get("Hdi_isfolder") == "true" # Sometimes, the service returns this metadata key capitalized 
+        )
+    )

--- a/py/runai_model_streamer_azure/runai_model_streamer_azure/files/tests/test_files.py
+++ b/py/runai_model_streamer_azure/runai_model_streamer_azure/files/tests/test_files.py
@@ -1,5 +1,7 @@
 import unittest
+from unittest.mock import MagicMock
 import runai_model_streamer_azure.files.files as files
+from azure.storage.blob import BlobProperties
 
 
 class TestFiles(unittest.TestCase):
@@ -32,6 +34,78 @@ class TestFiles(unittest.TestCase):
         res = files.removeprefix("test_prefix_string", "test_suffix_")
         self.assertEqual(res, "test_prefix_string")
 
+
+class TestListFiles(unittest.TestCase):
+
+    def make_blob(self, name, size=10, metadata=None):
+        blob = MagicMock(spec=BlobProperties)
+        blob.name = name
+        blob.size = size
+        blob.metadata = metadata
+        return blob
+    
+    # Returns mocked blob client for testing 
+    def make_mock_blob_client(self, blob_items, recursive=False):
+        mock_blob_client = MagicMock()
+        mock_container_client = MagicMock()
+
+        # Connect mocked_container_client
+        mock_blob_client.get_container_client.return_value = mock_container_client
+        if recursive:
+            mock_container_client.list_blobs.return_value = blob_items
+        else:
+            mock_container_client.walk_blobs.return_value = blob_items
+        return mock_blob_client
+
+    def test_listfiles_recursive(self):
+        # list_blobs and walk_blobs return an Iterable so list is fine
+        test_blobs = [
+            self.make_blob("file1.txt"),
+            self.make_blob("file2.txt"),
+            self.make_blob("dir1", size=0, metadata={"hdi_isfolder": "true"}),  # ADLS directory stub
+            self.make_blob("dir2"),
+            self.make_blob("dir3/", size=0, metadata={"hdi_isfolder": "false"}),
+        ]
+
+        client = self.make_mock_blob_client(blob_items=test_blobs, recursive=True)
+        _, _, result = files.list_files(client, "az://container/", recursive=True)
+        self.assertEqual(result, ["file1.txt", "file2.txt", "dir2"])
+    
+    def test_listfiles_non_recursive(self):
+        test_blobs = [
+            self.make_blob("file1.txt"),
+            self.make_blob("file2.txt"),
+            self.make_blob("dir1", size=0, metadata={"hdi_isfolder": "true"}),  # ADLS directory stub
+            self.make_blob("dir2"),
+            self.make_blob("dir3/", size=0, metadata={"hdi_isfolder": "false"}),
+        ]
+        client = self.make_mock_blob_client(blob_items=test_blobs)
+        _, _, result = files.list_files(client, "az://container/", )
+        self.assertEqual(result, ["file1.txt", "file2.txt", "dir2"])
+
+    def test_listfiles_with_allow_pattern(self):
+        blobs = [
+            self.make_blob("models/weights/config.json"),
+            self.make_blob("models/weights/model.safetensors"),
+            self.make_blob("models/README")
+        ]
+        client = self.make_mock_blob_client(blobs, recursive=True)
+        _, _, result = files.list_files(
+            client, "az://container/", allow_pattern=["*.safetensors"], recursive=True
+        )
+        self.assertEqual(result,["models/weights/model.safetensors"])
+
+    def test_listfiles_with_ignore_pattern(self):
+        blobs = [
+            self.make_blob("models/weights/config.json"),
+            self.make_blob("models/weights/model.safetensors"),
+            self.make_blob("models/README")
+        ]
+        client = self.make_mock_blob_client(blobs, recursive=True)
+        _, _, result = files.list_files(
+            client, "az://container/", ignore_pattern=["*.safetensors"], recursive=True
+        )
+        self.assertEqual(result, ["models/weights/config.json", "models/README"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/py/runai_model_streamer_azure/runai_model_streamer_azure/files/tests/test_files.py
+++ b/py/runai_model_streamer_azure/runai_model_streamer_azure/files/tests/test_files.py
@@ -74,7 +74,7 @@ class TestListFiles(unittest.TestCase):
             self.make_blob("adls-dir1", size=0, metadata={"hdi_isfolder": "true"}), 
             self.make_blob("dir2/"),
             self.make_blob("empty-blob", size=0),
-            self.make_blob("adls-caps", size=0, metadata={"Hdi_isfolder": "True"}),  
+            self.make_blob("adls-caps", size=0, metadata={"Hdi_isfolder": "true"}),  
             self.make_blob("empty-file", size=0, metadata={"Hdi_isfolder": "false"}),
         ]
 

--- a/py/runai_model_streamer_azure/runai_model_streamer_azure/files/tests/test_files.py
+++ b/py/runai_model_streamer_azure/runai_model_streamer_azure/files/tests/test_files.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock
 import runai_model_streamer_azure.files.files as files
-from azure.storage.blob import BlobProperties
+from azure.storage.blob import BlobProperties, BlobServiceClient, ContainerClient
 
 
 class TestFiles(unittest.TestCase):
@@ -44,44 +44,43 @@ class TestListFiles(unittest.TestCase):
         blob.metadata = metadata
         return blob
     
-    # Returns mocked blob client for testing 
-    def make_mock_blob_client(self, blob_items, recursive=False):
-        mock_blob_client = MagicMock()
-        mock_container_client = MagicMock()
-
-        # Connect mocked_container_client
-        mock_blob_client.get_container_client.return_value = mock_container_client
-        if recursive:
-            mock_container_client.list_blobs.return_value = blob_items
-        else:
-            mock_container_client.walk_blobs.return_value = blob_items
-        return mock_blob_client
+    def setUp(self):
+        self.mock_container_client = MagicMock(spec=ContainerClient)
+        self.mock_blob_client = MagicMock(spec=BlobServiceClient)
+        self.mock_blob_client.get_container_client.return_value = (
+            self.mock_container_client
+        )
 
     def test_listfiles_recursive(self):
         # list_blobs and walk_blobs return an Iterable so list is fine
         test_blobs = [
             self.make_blob("file1.txt"),
-            self.make_blob("file2.txt"),
-            self.make_blob("dir1", size=0, metadata={"hdi_isfolder": "true"}),  # ADLS directory stub
-            self.make_blob("dir2"),
-            self.make_blob("dir3/", size=0, metadata={"hdi_isfolder": "false"}),
+            self.make_blob("dir1/test.txt"),
+            self.make_blob("adls-dir1", size=0, metadata={"hdi_isfolder": "true"}),  # ADLS directory stub
+            self.make_blob("dir2/", size=0, metadata=None),
+            self.make_blob("empty-blob", size=0),
+            self.make_blob("adls-caps", size=0, metadata={"Hdi_isfolder": "true"}),  
+            self.make_blob("empty-file", size=0, metadata={"Hdi_isfolder": "false"}),
+        
         ]
 
-        client = self.make_mock_blob_client(blob_items=test_blobs, recursive=True)
-        _, _, result = files.list_files(client, "az://container/", recursive=True)
-        self.assertEqual(result, ["file1.txt", "file2.txt", "dir2"])
+        self.mock_container_client.list_blobs.return_value = test_blobs
+        _, _, result = files.list_files(self.mock_blob_client, "az://container/", recursive=True)
+        self.assertEqual(result, ["file1.txt", "dir1/test.txt", "empty-blob", "empty-file"])
     
     def test_listfiles_non_recursive(self):
         test_blobs = [
             self.make_blob("file1.txt"),
-            self.make_blob("file2.txt"),
-            self.make_blob("dir1", size=0, metadata={"hdi_isfolder": "true"}),  # ADLS directory stub
-            self.make_blob("dir2"),
-            self.make_blob("dir3/", size=0, metadata={"hdi_isfolder": "false"}),
+            self.make_blob("adls-dir1", size=0, metadata={"hdi_isfolder": "true"}), 
+            self.make_blob("dir2/"),
+            self.make_blob("empty-blob", size=0),
+            self.make_blob("adls-caps", size=0, metadata={"Hdi_isfolder": "True"}),  
+            self.make_blob("empty-file", size=0, metadata={"Hdi_isfolder": "false"}),
         ]
-        client = self.make_mock_blob_client(blob_items=test_blobs)
-        _, _, result = files.list_files(client, "az://container/", )
-        self.assertEqual(result, ["file1.txt", "file2.txt", "dir2"])
+
+        self.mock_container_client.walk_blobs.return_value = test_blobs
+        _, _, result = files.list_files(self.mock_blob_client, "az://container/", )
+        self.assertEqual(result, ["file1.txt", "empty-blob", "empty-file"])
 
     def test_listfiles_with_allow_pattern(self):
         blobs = [
@@ -89,9 +88,10 @@ class TestListFiles(unittest.TestCase):
             self.make_blob("models/weights/model.safetensors"),
             self.make_blob("models/README")
         ]
-        client = self.make_mock_blob_client(blobs, recursive=True)
+       
+        self.mock_container_client.list_blobs.return_value = blobs
         _, _, result = files.list_files(
-            client, "az://container/", allow_pattern=["*.safetensors"], recursive=True
+            self.mock_blob_client, "az://container/", allow_pattern=["*.safetensors"], recursive=True
         )
         self.assertEqual(result,["models/weights/model.safetensors"])
 
@@ -101,9 +101,9 @@ class TestListFiles(unittest.TestCase):
             self.make_blob("models/weights/model.safetensors"),
             self.make_blob("models/README")
         ]
-        client = self.make_mock_blob_client(blobs, recursive=True)
+        self.mock_container_client.list_blobs.return_value = blobs
         _, _, result = files.list_files(
-            client, "az://container/", ignore_pattern=["*.safetensors"], recursive=True
+            self.mock_blob_client, "az://container/", ignore_pattern=["*.safetensors"], recursive=True
         )
         self.assertEqual(result, ["models/weights/config.json", "models/README"])
 


### PR DESCRIPTION

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->
Previously, directory stubs (that did not end with a trailing slash) were not being filtered properly.  The API lists directories as blobs, which causes the model streamer to attempt to download directories as if they were files. This results in errors such as `IsADirectoryError` when the streamer tries to create a file where a directory already exists

This PR introduces a mechanism to rely on the blob directory metatdata `hdi_isfolder` to determine the entity type (either directory or file) 


#### Testing: 
Added unit tests, 
Manually imported the module for validation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Listing results now reliably exclude ADLS/HNS directory stubs by inspecting blob metadata (case-insensitive) and size, for both recursive and non-recursive listings — reducing false-positive directories.

* **Tests**
  * Added tests covering recursive/non-recursive listings and allow/ignore pattern filtering (e.g., include/exclude by extension) to validate the corrected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->