### PR TITLE
Fix absolute-form HTTP request URIs when endpointOverride includes scheme

### DIFF
--- a/cpp/s3/client/BUILD
+++ b/cpp/s3/client/BUILD
@@ -1,4 +1,4 @@
-load("//:rules.bzl", "runai_cc_auto_library")
+load("//:rules.bzl", "runai_cc_auto_library", "runai_cc_test")
 
 runai_cc_auto_library(
     name = "client",
@@ -16,4 +16,10 @@ runai_cc_auto_library(
         "//utils/env",
         "//utils/fd",
     ],
+)
+
+runai_cc_test(
+    name = "client_test",
+    srcs = ["client_test.cc"],
+    deps = [":client"],
 )

--- a/cpp/s3/client/client.cc
+++ b/cpp/s3/client/client.cc
@@ -1,4 +1,5 @@
 
+#include <aws/core/http/Scheme.h>
 #include <aws/s3-crt/model/GetObjectRequest.h>
 
 #include <cstring>
@@ -18,6 +19,34 @@
 
 namespace runai::llm::streamer::impl::s3
 {
+
+static bool starts_with_ci(const Aws::String & str, const Aws::String & prefix)
+{
+    if (str.size() < prefix.size()) return false;
+    for (size_t i = 0; i < prefix.size(); ++i)
+    {
+        if (std::tolower(static_cast<unsigned char>(str[i])) !=
+            std::tolower(static_cast<unsigned char>(prefix[i])))
+            return false;
+    }
+    return true;
+}
+
+EndpointParseResult parse_endpoint_scheme(const Aws::String & endpoint)
+{
+    const Aws::String https_prefix("https://");
+    const Aws::String http_prefix("http://");
+
+    if (starts_with_ci(endpoint, https_prefix))
+    {
+        return { endpoint.substr(https_prefix.size()), Aws::Http::Scheme::HTTPS };
+    }
+    if (starts_with_ci(endpoint, http_prefix))
+    {
+        return { endpoint.substr(http_prefix.size()), Aws::Http::Scheme::HTTP };
+    }
+    return { endpoint, Aws::Http::Scheme::HTTPS };
+}
 
 std::optional<Aws::String> convert(const char * input)
 {
@@ -105,7 +134,20 @@ S3Client::S3Client(const common::backend_api::ObjectClientConfig_t & config) :
 {
     if (_endpoint.has_value()) // endpoint passed as parameter by user application (in credentials)
     {
-        _client_config.config.endpointOverride = _endpoint.value();
+        // Strip the scheme from the endpoint and set it separately.
+        // Including http:// in endpointOverride causes the CRT to produce
+        // absolute-form request lines (GET http://host/path) which most
+        // S3-compatible servers reject.
+        auto parsed = parse_endpoint_scheme(_endpoint.value());
+        if (parsed.host.empty())
+        {
+            LOG(ERROR) << "Endpoint is empty after stripping scheme from " << _endpoint.value();
+            throw common::Exception(common::ResponseCode::FileAccessError);
+        }
+        _client_config.config.endpointOverride = parsed.host;
+        _client_config.config.scheme = parsed.scheme;
+        LOG(DEBUG) << "Setting endpoint override to " << parsed.host
+                   << " with scheme " << (parsed.scheme == Aws::Http::Scheme::HTTPS ? "HTTPS" : "HTTP");
     }
 
     if (utils::try_getenv("RUNAI_STREAMER_S3_USE_VIRTUAL_ADDRESSING", _client_config.config.useVirtualAddressing))

--- a/cpp/s3/client/client.h
+++ b/cpp/s3/client/client.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <optional>
 
+#include <aws/core/http/Scheme.h>
+
 #include "s3/client_configuration/client_configuration.h"
 #include "common/backend_api/response/response.h"
 
@@ -17,6 +19,17 @@
 
 namespace runai::llm::streamer::impl::s3
 {
+
+// Strip the scheme (http:// or https://) from an endpoint URL and return the
+// corresponding Aws::Http::Scheme.  When no scheme is present the endpoint is
+// returned unchanged and the scheme defaults to HTTPS.
+struct EndpointParseResult
+{
+    Aws::String host;
+    Aws::Http::Scheme scheme;
+};
+
+EndpointParseResult parse_endpoint_scheme(const Aws::String & endpoint);
 
 struct S3ClientBase : common::IClient
 {

--- a/cpp/s3/client/client_test.cc
+++ b/cpp/s3/client/client_test.cc
@@ -1,0 +1,93 @@
+#include "s3/client/client.h"
+
+#include <gtest/gtest.h>
+
+namespace runai::llm::streamer::impl::s3
+{
+
+TEST(ParseEndpointScheme, HttpPrefix)
+{
+    auto result = parse_endpoint_scheme("http://10.1.254.10");
+    EXPECT_EQ(result.host, "10.1.254.10");
+    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTP);
+}
+
+TEST(ParseEndpointScheme, HttpPrefixWithPort)
+{
+    auto result = parse_endpoint_scheme("http://10.1.254.10:9000");
+    EXPECT_EQ(result.host, "10.1.254.10:9000");
+    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTP);
+}
+
+TEST(ParseEndpointScheme, HttpsPrefix)
+{
+    auto result = parse_endpoint_scheme("https://s3.amazonaws.com");
+    EXPECT_EQ(result.host, "s3.amazonaws.com");
+    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTPS);
+}
+
+TEST(ParseEndpointScheme, HttpsPrefixWithPort)
+{
+    auto result = parse_endpoint_scheme("https://cwobject.com:443");
+    EXPECT_EQ(result.host, "cwobject.com:443");
+    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTPS);
+}
+
+TEST(ParseEndpointScheme, NoScheme)
+{
+    auto result = parse_endpoint_scheme("10.1.254.10");
+    EXPECT_EQ(result.host, "10.1.254.10");
+    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTPS);
+}
+
+TEST(ParseEndpointScheme, NoSchemeWithPort)
+{
+    auto result = parse_endpoint_scheme("localhost:9000");
+    EXPECT_EQ(result.host, "localhost:9000");
+    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTPS);
+}
+
+TEST(ParseEndpointScheme, EmptyString)
+{
+    auto result = parse_endpoint_scheme("");
+    EXPECT_EQ(result.host, "");
+    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTPS);
+}
+
+TEST(ParseEndpointScheme, HttpInHostname)
+{
+    // Ensure we only strip the scheme prefix, not "http" appearing elsewhere
+    auto result = parse_endpoint_scheme("httpbin.org");
+    EXPECT_EQ(result.host, "httpbin.org");
+    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTPS);
+}
+
+TEST(ParseEndpointScheme, HttpUpperCase)
+{
+    auto result = parse_endpoint_scheme("HTTP://10.1.254.10");
+    EXPECT_EQ(result.host, "10.1.254.10");
+    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTP);
+}
+
+TEST(ParseEndpointScheme, HttpsMixedCase)
+{
+    auto result = parse_endpoint_scheme("Https://s3.example.com");
+    EXPECT_EQ(result.host, "s3.example.com");
+    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTPS);
+}
+
+TEST(ParseEndpointScheme, HttpSchemeOnly)
+{
+    auto result = parse_endpoint_scheme("http://");
+    EXPECT_EQ(result.host, "");
+    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTP);
+}
+
+TEST(ParseEndpointScheme, HttpsSchemeOnly)
+{
+    auto result = parse_endpoint_scheme("https://");
+    EXPECT_EQ(result.host, "");
+    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTPS);
+}
+
+}; // namespace runai::llm::streamer::impl::s3


### PR DESCRIPTION
## Problem

When `AWS_ENDPOINT_URL` (or credentials endpoint) is set with a scheme prefix (e.g. `http://10.1.254.10`), the value is passed directly to `S3CrtClient`'s `endpointOverride`. The CRT then constructs HTTP requests with absolute-form URIs:

```
GET http://10.1.254.10/bucket/key HTTP/1.1
Host: 10.1.254.10
```

instead of the expected origin-form:

```
GET /bucket/key HTTP/1.1
Host: 10.1.254.10
```

S3-compatible servers (VAST S3, and potentially others) reject absolute-form request lines with `400 Bad Request` because they parse the scheme as part of the bucket name. For example, VAST returns:

```xml
<Error>
  <Code>InvalidBucketName</Code>
  <Message>Illegal @s3_bucket_name=ttp: (4)</Message>
</Error>
```

This only affects plain HTTP endpoints. HTTPS endpoints work because the CRT uses origin-form for TLS connections. It also doesn't affect virtual-addressed endpoints (like CoreWeave's `cwlota`) because the bucket is in the `Host` header, not the URI path.

## Fix

Strip the `http://` or `https://` scheme prefix from the endpoint URL before setting `endpointOverride`, and set `config.scheme` to `Aws::Http::Scheme::HTTP` or `Aws::Http::Scheme::HTTPS` accordingly. This tells the CRT the correct protocol without embedding the scheme in the request URI.

## Reproduction

```bash
nc -l -p 9000 &
AWS_ENDPOINT_URL="http://127.0.0.1:9000" \
RUNAI_STREAMER_S3_USE_VIRTUAL_ADDRESSING=0 \
AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
AWS_EC2_METADATA_DISABLED=true \
python -c "
from runai_model_streamer import SafetensorsStreamer
with SafetensorsStreamer() as s:
    s.stream_file('s3://bucket/key.safetensors')
"
# Before fix: GET http://127.0.0.1:9000/bucket/key.safetensors HTTP/1.1
# After fix:  GET /bucket/key.safetensors HTTP/1.1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 endpoint handling: the client now detects and separates HTTP/HTTPS prefixes (defaults to HTTPS when missing) and validates non-empty host portions.
* **Tests**
  * Added comprehensive unit tests covering endpoint parsing (http/https, case variations, ports, missing or empty inputs).
* **Chores**
  * Added a C++ test target to run the new endpoint parsing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->