### PR TITLE
Address PR #150 review feedback for endpoint scheme parsing

### DIFF
--- a/cpp/s3/client/client.cc
+++ b/cpp/s3/client/client.cc
@@ -45,7 +45,7 @@ EndpointParseResult parse_endpoint_scheme(const Aws::String & endpoint)
     {
         return { endpoint.substr(http_prefix.size()), Aws::Http::Scheme::HTTP };
     }
-    return { endpoint, Aws::Http::Scheme::HTTPS };
+    return { endpoint, std::nullopt };
 }
 
 std::optional<Aws::String> convert(const char * input)
@@ -139,15 +139,22 @@ S3Client::S3Client(const common::backend_api::ObjectClientConfig_t & config) :
         // absolute-form request lines (GET http://host/path) which most
         // S3-compatible servers reject.
         auto parsed = parse_endpoint_scheme(_endpoint.value());
-        if (parsed.host.empty())
+        if (parsed.host.empty() || parsed.host[0] == ':')
         {
-            LOG(ERROR) << "Endpoint is empty after stripping scheme from " << _endpoint.value();
+            LOG(ERROR) << "Invalid endpoint (no host): " << _endpoint.value();
             throw common::Exception(common::ResponseCode::FileAccessError);
         }
         _client_config.config.endpointOverride = parsed.host;
-        _client_config.config.scheme = parsed.scheme;
-        LOG(DEBUG) << "Setting endpoint override to " << parsed.host
-                   << " with scheme " << (parsed.scheme == Aws::Http::Scheme::HTTPS ? "HTTPS" : "HTTP");
+        if (parsed.scheme.has_value())
+        {
+            _client_config.config.scheme = parsed.scheme.value();
+            LOG(DEBUG) << "Setting endpoint override to " << parsed.host
+                       << " with scheme " << (parsed.scheme.value() == Aws::Http::Scheme::HTTPS ? "HTTPS" : "HTTP");
+        }
+        else
+        {
+            LOG(DEBUG) << "Setting endpoint override to " << parsed.host << " (no explicit scheme)";
+        }
     }
 
     if (utils::try_getenv("RUNAI_STREAMER_S3_USE_VIRTUAL_ADDRESSING", _client_config.config.useVirtualAddressing))

--- a/cpp/s3/client/client.h
+++ b/cpp/s3/client/client.h
@@ -20,13 +20,10 @@
 namespace runai::llm::streamer::impl::s3
 {
 
-// Strip the scheme (http:// or https://) from an endpoint URL and return the
-// corresponding Aws::Http::Scheme.  When no scheme is present the endpoint is
-// returned unchanged and the scheme defaults to HTTPS.
 struct EndpointParseResult
 {
     Aws::String host;
-    Aws::Http::Scheme scheme;
+    std::optional<Aws::Http::Scheme> scheme;
 };
 
 EndpointParseResult parse_endpoint_scheme(const Aws::String & endpoint);

--- a/cpp/s3/client/client_test.cc
+++ b/cpp/s3/client/client_test.cc
@@ -9,49 +9,53 @@ TEST(ParseEndpointScheme, HttpPrefix)
 {
     auto result = parse_endpoint_scheme("http://10.1.254.10");
     EXPECT_EQ(result.host, "10.1.254.10");
-    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTP);
+    ASSERT_TRUE(result.scheme.has_value());
+    EXPECT_EQ(result.scheme.value(), Aws::Http::Scheme::HTTP);
 }
 
 TEST(ParseEndpointScheme, HttpPrefixWithPort)
 {
     auto result = parse_endpoint_scheme("http://10.1.254.10:9000");
     EXPECT_EQ(result.host, "10.1.254.10:9000");
-    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTP);
+    ASSERT_TRUE(result.scheme.has_value());
+    EXPECT_EQ(result.scheme.value(), Aws::Http::Scheme::HTTP);
 }
 
 TEST(ParseEndpointScheme, HttpsPrefix)
 {
     auto result = parse_endpoint_scheme("https://s3.amazonaws.com");
     EXPECT_EQ(result.host, "s3.amazonaws.com");
-    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTPS);
+    ASSERT_TRUE(result.scheme.has_value());
+    EXPECT_EQ(result.scheme.value(), Aws::Http::Scheme::HTTPS);
 }
 
 TEST(ParseEndpointScheme, HttpsPrefixWithPort)
 {
     auto result = parse_endpoint_scheme("https://cwobject.com:443");
     EXPECT_EQ(result.host, "cwobject.com:443");
-    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTPS);
+    ASSERT_TRUE(result.scheme.has_value());
+    EXPECT_EQ(result.scheme.value(), Aws::Http::Scheme::HTTPS);
 }
 
 TEST(ParseEndpointScheme, NoScheme)
 {
     auto result = parse_endpoint_scheme("10.1.254.10");
     EXPECT_EQ(result.host, "10.1.254.10");
-    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTPS);
+    EXPECT_FALSE(result.scheme.has_value());
 }
 
 TEST(ParseEndpointScheme, NoSchemeWithPort)
 {
     auto result = parse_endpoint_scheme("localhost:9000");
     EXPECT_EQ(result.host, "localhost:9000");
-    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTPS);
+    EXPECT_FALSE(result.scheme.has_value());
 }
 
 TEST(ParseEndpointScheme, EmptyString)
 {
     auto result = parse_endpoint_scheme("");
     EXPECT_EQ(result.host, "");
-    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTPS);
+    EXPECT_FALSE(result.scheme.has_value());
 }
 
 TEST(ParseEndpointScheme, HttpInHostname)
@@ -59,35 +63,47 @@ TEST(ParseEndpointScheme, HttpInHostname)
     // Ensure we only strip the scheme prefix, not "http" appearing elsewhere
     auto result = parse_endpoint_scheme("httpbin.org");
     EXPECT_EQ(result.host, "httpbin.org");
-    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTPS);
+    EXPECT_FALSE(result.scheme.has_value());
 }
 
 TEST(ParseEndpointScheme, HttpUpperCase)
 {
     auto result = parse_endpoint_scheme("HTTP://10.1.254.10");
     EXPECT_EQ(result.host, "10.1.254.10");
-    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTP);
+    ASSERT_TRUE(result.scheme.has_value());
+    EXPECT_EQ(result.scheme.value(), Aws::Http::Scheme::HTTP);
 }
 
 TEST(ParseEndpointScheme, HttpsMixedCase)
 {
     auto result = parse_endpoint_scheme("Https://s3.example.com");
     EXPECT_EQ(result.host, "s3.example.com");
-    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTPS);
+    ASSERT_TRUE(result.scheme.has_value());
+    EXPECT_EQ(result.scheme.value(), Aws::Http::Scheme::HTTPS);
 }
 
 TEST(ParseEndpointScheme, HttpSchemeOnly)
 {
     auto result = parse_endpoint_scheme("http://");
     EXPECT_EQ(result.host, "");
-    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTP);
+    ASSERT_TRUE(result.scheme.has_value());
+    EXPECT_EQ(result.scheme.value(), Aws::Http::Scheme::HTTP);
 }
 
 TEST(ParseEndpointScheme, HttpsSchemeOnly)
 {
     auto result = parse_endpoint_scheme("https://");
     EXPECT_EQ(result.host, "");
-    EXPECT_EQ(result.scheme, Aws::Http::Scheme::HTTPS);
+    ASSERT_TRUE(result.scheme.has_value());
+    EXPECT_EQ(result.scheme.value(), Aws::Http::Scheme::HTTPS);
+}
+
+TEST(ParseEndpointScheme, PortWithoutHost)
+{
+    auto result = parse_endpoint_scheme("http://:9000");
+    EXPECT_EQ(result.host, ":9000");
+    ASSERT_TRUE(result.scheme.has_value());
+    EXPECT_EQ(result.scheme.value(), Aws::Http::Scheme::HTTP);
 }
 
 }; // namespace runai::llm::streamer::impl::s3


### PR DESCRIPTION
## Summary

Follow-up to #150 addressing @noa-neria's review comments:

- **Optional scheme**: `EndpointParseResult.scheme` is now `std::optional<Aws::Http::Scheme>` — `config.scheme` is only set when the user explicitly specified a scheme prefix (no more silent default to HTTPS)
- **Reject port-only endpoints**: Validation now also rejects hosts starting with `:` (e.g. `http://:9000`)
- **Remove header comment**: Removed the explanatory comment above `EndpointParseResult` in `client.h`

## Test plan

- [ ] Existing `ParseEndpointScheme` tests updated to validate optional scheme behavior
- [ ] New `PortWithoutHost` test added for `http://:9000`
- [ ] No-scheme cases (`10.1.254.10`, `localhost:9000`, `httpbin.org`, empty string) now assert `scheme` is `nullopt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved endpoint handling so addresses without an explicit `http://` or `https://` prefix are no longer assumed to use HTTPS.
  * Tightened validation for endpoint overrides, returning clearer errors for invalid host formats.
  * Preserved explicit scheme handling when a scheme is provided, while leaving scheme unset when none is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->