### PR TITLE
capacity controlled streaming from object storage

### DIFF
--- a/cpp/azure/azure.cc
+++ b/cpp/azure/azure.cc
@@ -118,7 +118,7 @@ common::backend_api::ResponseCode_t obj_get_backend_config(common::backend_api::
     }
     catch(const std::exception& e)
     {
-        LOG(ERROR) << "Caught exception in obj_get_backend_config";
+        LOG(ERROR) << "Caught exception in obj_get_backend_config: " << e.what();
     }
     return common::ResponseCode::UnknownError;
 }

--- a/cpp/azure/azure.cc
+++ b/cpp/azure/azure.cc
@@ -1,10 +1,15 @@
 #include "azure/azure.h"
 #include "azure/client/client.h"
 
+#include <atomic>
+#include <cstdio>
+#include <cstring>
+
 #include "common/backend_api/object_storage/list_files_impl.h"
 #include "common/client_mgr/client_mgr.h"
 #include "common/exception/exception.h"
 #include "utils/env/env.h"
+#include "utils/logging/logging.h"
 #include "utils/semver/semver.h"
 
 // For connecting to Azure Blob Storage:
@@ -17,6 +22,11 @@ namespace runai::llm::streamer::impl::azure
 
 inline constexpr char AzureClientName[] = "Azure";
 using AzureClientMgr = common::ClientMgr<AzureClient, AzureClientName>;
+
+// In-flight window advertised via obj_get_backend_config("max_inflight_bytes"). Populated
+// when a client is created (AzureClient computes it from its async threadpool size and
+// default_storage_chunk_size). Uniform across clients in a process; SIZE_MAX = unset/unbounded.
+static std::atomic<size_t> g_max_inflight_bytes{static_cast<size_t>(-1)};
 
 // --- Backend API ---
 
@@ -68,6 +78,51 @@ common::backend_api::ObjectShutdownPolicy_t obj_get_backend_shutdown_policy()
     return common::backend_api::OBJECT_SHUTDOWN_POLICY_ON_PROCESS_EXIT;
 }
 
+common::backend_api::ResponseCode_t obj_get_backend_config(common::backend_api::ObjectBackendHandle_t /* backend_handle */,
+                                                           const char* key,
+                                                           char* out_value_buffer,
+                                                           unsigned int* in_out_buffer_len)
+{
+    try
+    {
+        if (!key || !out_value_buffer || !in_out_buffer_len)
+        {
+            LOG(ERROR) << "obj_get_backend_config called with null argument(s)";
+            return common::ResponseCode::UnknownError;
+        }
+
+        if (std::strcmp(key, "max_inflight_bytes") == 0)
+        {
+            char tmp[32];
+            const int n = std::snprintf(tmp, sizeof(tmp), "%zu", g_max_inflight_bytes.load());
+            if (n < 0 || n >= static_cast<int>(sizeof(tmp)))
+            {
+                LOG(ERROR) << "Failed to format max_inflight_bytes value";
+                return common::ResponseCode::UnknownError;
+            }
+            const unsigned int needed = static_cast<unsigned int>(n) + 1;   // including null terminator
+            if (*in_out_buffer_len < needed)
+            {
+                LOG(ERROR) << "obj_get_backend_config buffer too small for key '" << key
+                           << "': need " << needed << " bytes, have " << *in_out_buffer_len;
+                *in_out_buffer_len = needed;   // report required size to the caller
+                return common::ResponseCode::UnknownError;
+            }
+            std::memcpy(out_value_buffer, tmp, needed);
+            *in_out_buffer_len = static_cast<unsigned int>(n);   // written length, excluding null terminator
+            return common::ResponseCode::Success;
+        }
+
+        LOG(WARNING) << "Unknown backend config key: " << key;
+        return common::ResponseCode::UnknownError;
+    }
+    catch(const std::exception& e)
+    {
+        LOG(ERROR) << "Caught exception in obj_get_backend_config";
+    }
+    return common::ResponseCode::UnknownError;
+}
+
 // --- Client API ---
 
 common::backend_api::ResponseCode_t obj_create_client(common::backend_api::ObjectBackendHandle_t backend_handle,
@@ -78,6 +133,7 @@ common::backend_api::ResponseCode_t obj_create_client(common::backend_api::Objec
     try
     {
         *out_client_handle = AzureClientMgr::pop(*client_initial_config);
+        g_max_inflight_bytes.store(static_cast<AzureClient *>(*out_client_handle)->max_inflight_bytes());
     }
     catch(const common::Exception & e)
     {

--- a/cpp/azure/azure.h
+++ b/cpp/azure/azure.h
@@ -47,6 +47,13 @@ extern "C" common::backend_api::ResponseCode_t obj_open_backend(common::backend_
 extern "C" common::backend_api::ResponseCode_t obj_close_backend(common::backend_api::ObjectBackendHandle_t backend_handle);
 extern "C" common::backend_api::ObjectShutdownPolicy_t obj_get_backend_shutdown_policy();
 
+extern "C" common::backend_api::ResponseCode_t obj_get_backend_config(
+    common::backend_api::ObjectBackendHandle_t backend_handle,
+    const char* key,
+    char* out_value_buffer,
+    unsigned int* in_out_buffer_len
+);
+
 // --- Client API ---
 
 extern "C" common::backend_api::ResponseCode_t obj_create_client(

--- a/cpp/azure/azure.ldscript
+++ b/cpp/azure/azure.ldscript
@@ -3,6 +3,7 @@
     obj_open_backend;
     obj_close_backend;
     obj_get_backend_shutdown_policy;
+    obj_get_backend_config;
     obj_create_client;
     obj_remove_client;
     obj_request_read;

--- a/cpp/azure/client/client.cc
+++ b/cpp/azure/client/client.cc
@@ -32,6 +32,12 @@ AzureClient::AzureClient(const common::backend_api::ObjectClientConfig_t& config
     _responder(nullptr),
     _chunk_bytesize(config.default_storage_chunk_size)
 {
+    // advertise an in-flight window sized to the async threadpool: margin x pool x chunk,
+    // floored at two chunks so the window can always keep the pool busy
+    _max_inflight_bytes = std::max(
+        static_cast<size_t>(common::backend_api::inflight_window_margin() * _client_config.max_concurrency * _chunk_bytesize),
+        static_cast<size_t>(2) * _chunk_bytesize);
+
     // ClientConfiguration reads environment variables
     _account_name = _client_config.account_name;
     _account_key = _client_config.account_key;

--- a/cpp/azure/client/client.h
+++ b/cpp/azure/client/client.h
@@ -44,11 +44,15 @@ struct AzureClient : common::IClient
     // If stopped before all requests for an async_read() call are sent, subsequent request chunks will not be sent.
     void stop();
 
+    // In-flight window (bytes) advertised to the generic layer: async threadpool size x chunk x margin
+    size_t max_inflight_bytes() const { return _max_inflight_bytes; }
+
  private:
     std::atomic<bool> _stop;
     ClientConfiguration _client_config;
     const size_t _chunk_bytesize;
-    
+    size_t _max_inflight_bytes = 0;
+
     // Azure credentials
     std::optional<std::string> _account_name;
     std::optional<std::string> _account_key;

--- a/cpp/common/backend_api/object_storage/BUILD
+++ b/cpp/common/backend_api/object_storage/BUILD
@@ -4,6 +4,7 @@ runai_cc_auto_library(
     name = "object_storage",
     deps = [
         "//common/response",
+        "//utils/logging",
     ],
 )
 

--- a/cpp/common/backend_api/object_storage/BUILD
+++ b/cpp/common/backend_api/object_storage/BUILD
@@ -17,3 +17,12 @@ runai_cc_test(
         "//utils/logging",
     ],
 )
+
+runai_cc_test(
+    name = "object_storage_test",
+    srcs = ["object_storage_test.cc"],
+    deps = [
+        ":object_storage",
+        "//utils/temp/env",
+    ],
+)

--- a/cpp/common/backend_api/object_storage/object_storage.h
+++ b/cpp/common/backend_api/object_storage/object_storage.h
@@ -39,7 +39,7 @@ inline double inflight_window_margin()
     {
         char* end = nullptr;
         const double value = std::strtod(env, &end);
-        if (end != env && value > 0.0)
+        if (end != env && *end == '\0' && value > 0.0)
         {
             return value;
         }

--- a/cpp/common/backend_api/object_storage/object_storage.h
+++ b/cpp/common/backend_api/object_storage/object_storage.h
@@ -1,10 +1,8 @@
 #pragma once
 
 #include <cstdint>
-#include <cstdlib>
 
 #include "common/response/response.h"
-#include "utils/logging/logging.h"
 
 namespace runai::llm::streamer::common::backend_api
 {
@@ -33,21 +31,7 @@ using ResponseCode_t = common::ResponseCode;
 // max_inflight_bytes (see obj_get_backend_config), giving completion-driven refill enough
 // headroom to keep the backend busy during the completion -> resubmit round-trip.
 // Defaults to 1.5; override with RUNAI_STREAMER_INFLIGHT_WINDOW_MARGIN (a positive float).
-inline double inflight_window_margin()
-{
-    if (const char* env = std::getenv("RUNAI_STREAMER_INFLIGHT_WINDOW_MARGIN"))
-    {
-        char* end = nullptr;
-        const double value = std::strtod(env, &end);
-        if (end != env && *end == '\0' && value > 0.0)
-        {
-            return value;
-        }
-        LOG(ERROR) << "Ignoring invalid RUNAI_STREAMER_INFLIGHT_WINDOW_MARGIN='" << env
-                   << "'; expected a positive float, using default 1.5";
-    }
-    return 1.5;
-}
+double inflight_window_margin();
 
 // --- Config Params ---
 struct ObjectConfigParam_t

--- a/cpp/common/backend_api/object_storage/object_storage.h
+++ b/cpp/common/backend_api/object_storage/object_storage.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <cstdint>
+#include <cstdlib>
 
 #include "common/response/response.h"
+#include "utils/logging/logging.h"
 
 namespace runai::llm::streamer::common::backend_api
 {
@@ -26,6 +28,26 @@ typedef enum {
 } ObjectShutdownPolicy_t;
 
 using ResponseCode_t = common::ResponseCode;
+
+// Multiplier applied to a backend's raw in-flight capacity when advertising
+// max_inflight_bytes (see obj_get_backend_config), giving completion-driven refill enough
+// headroom to keep the backend busy during the completion -> resubmit round-trip.
+// Defaults to 1.5; override with RUNAI_STREAMER_INFLIGHT_WINDOW_MARGIN (a positive float).
+inline double inflight_window_margin()
+{
+    if (const char* env = std::getenv("RUNAI_STREAMER_INFLIGHT_WINDOW_MARGIN"))
+    {
+        char* end = nullptr;
+        const double value = std::strtod(env, &end);
+        if (end != env && value > 0.0)
+        {
+            return value;
+        }
+        LOG(ERROR) << "Ignoring invalid RUNAI_STREAMER_INFLIGHT_WINDOW_MARGIN='" << env
+                   << "'; expected a positive float, using default 1.5";
+    }
+    return 1.5;
+}
 
 // --- Config Params ---
 struct ObjectConfigParam_t

--- a/cpp/common/backend_api/object_storage/object_storage_test.cc
+++ b/cpp/common/backend_api/object_storage/object_storage_test.cc
@@ -1,0 +1,59 @@
+#include "common/backend_api/object_storage/object_storage.h"
+
+#include <gtest/gtest.h>
+
+#include "utils/temp/env/env.h"
+
+namespace runai::llm::streamer::common::backend_api
+{
+
+namespace
+{
+
+constexpr char MarginEnvVar[] = "RUNAI_STREAMER_INFLIGHT_WINDOW_MARGIN";
+
+} // namespace
+
+TEST(InflightWindowMargin, DefaultWhenUnset)
+{
+    utils::temp::UnsetEnv unset(MarginEnvVar);
+    EXPECT_DOUBLE_EQ(inflight_window_margin(), 1.5);
+}
+
+TEST(InflightWindowMargin, ValidPositiveFloat)
+{
+    utils::temp::UnsetEnv unset(MarginEnvVar);
+    utils::temp::Env env(MarginEnvVar, "2.0");
+    EXPECT_DOUBLE_EQ(inflight_window_margin(), 2.0);
+}
+
+TEST(InflightWindowMargin, TrailingGarbageRejected)
+{
+    // a numeric prefix followed by junk must not be silently accepted as the prefix value
+    utils::temp::UnsetEnv unset(MarginEnvVar);
+    utils::temp::Env env(MarginEnvVar, "2.0garbage");
+    EXPECT_DOUBLE_EQ(inflight_window_margin(), 1.5);
+}
+
+TEST(InflightWindowMargin, NonNumericRejected)
+{
+    utils::temp::UnsetEnv unset(MarginEnvVar);
+    utils::temp::Env env(MarginEnvVar, "abc");
+    EXPECT_DOUBLE_EQ(inflight_window_margin(), 1.5);
+}
+
+TEST(InflightWindowMargin, NonPositiveRejected)
+{
+    {
+        utils::temp::UnsetEnv unset(MarginEnvVar);
+        utils::temp::Env env(MarginEnvVar, "0");
+        EXPECT_DOUBLE_EQ(inflight_window_margin(), 1.5);
+    }
+    {
+        utils::temp::UnsetEnv unset(MarginEnvVar);
+        utils::temp::Env env(MarginEnvVar, "-2.0");
+        EXPECT_DOUBLE_EQ(inflight_window_margin(), 1.5);
+    }
+}
+
+} // namespace runai::llm::streamer::common::backend_api

--- a/cpp/common/backend_api/object_storage/utils.cc
+++ b/cpp/common/backend_api/object_storage/utils.cc
@@ -1,7 +1,27 @@
 #include "common/backend_api/object_storage/utils.h"
 
+#include <cstdlib>
+
+#include "utils/logging/logging.h"
+
 namespace runai::llm::streamer::common::backend_api
 {
+
+double inflight_window_margin()
+{
+    if (const char* env = std::getenv("RUNAI_STREAMER_INFLIGHT_WINDOW_MARGIN"))
+    {
+        char* end = nullptr;
+        const double value = std::strtod(env, &end);
+        if (end != env && *end == '\0' && value > 0.0)
+        {
+            return value;
+        }
+        LOG(ERROR) << "Ignoring invalid RUNAI_STREAMER_INFLIGHT_WINDOW_MARGIN='" << env
+                   << "'; expected a positive float, using default 1.5";
+    }
+    return 1.5;
+}
 
 std::ostream & operator<<(std::ostream & os, const ObjectConfigParam_t & param)
 {

--- a/cpp/common/response_code/response_code.cc
+++ b/cpp/common/response_code/response_code.cc
@@ -37,6 +37,8 @@ constexpr std::array<const char *, static_cast<size_t>(ResponseCode::__Max)> __m
     "Unknown Error",
     "Error loading object storage plugin",
     "GCS not supported",
+    "Azure Blob not supported",
+    "Object storage returned an unexpected number of bytes for the requested range (truncated or over-length response)",
 };
 
 const char * description(int response_code)

--- a/cpp/common/response_code/response_code.h
+++ b/cpp/common/response_code/response_code.h
@@ -24,6 +24,7 @@ enum class ResponseCode : int
     ObjPluginLoadError,
     GCSNotSupported,
     AzureBlobNotSupported,
+    FileTruncatedError,
     __Max,
 };
 

--- a/cpp/common/s3_wrapper/s3_wrapper.cc
+++ b/cpp/common/s3_wrapper/s3_wrapper.cc
@@ -1,6 +1,7 @@
 #include <regex>
 #include <vector>
 #include <chrono>
+#include <cstdlib>
 
 #include "common/s3_wrapper/s3_wrapper.h"
 #include "common/s3_credentials/s3_credentials.h"
@@ -51,6 +52,42 @@ const common::backend_api::ObjectClientConfig_t S3ClientWrapper::Params::to_conf
     config.initial_params = initial_params.data();
     config.default_storage_chunk_size = chunk_bytesize;
     return config;
+}
+
+size_t S3ClientWrapper::max_inflight_bytes()
+{
+    constexpr size_t unbounded = static_cast<size_t>(-1);
+
+    if (_backend_handle == nullptr)
+    {
+        return unbounded;
+    }
+
+    try
+    {
+        auto get_config_ = _backend_handle->dylib_ptr->dlsym<common::backend_api::ResponseCode_t(*)(
+            common::backend_api::ObjectBackendHandle_t, const char*, char*, unsigned int*)>("obj_get_backend_config");
+        if (get_config_ == nullptr)
+        {
+            return unbounded;
+        }
+
+        char buf[32] = {0};
+        unsigned int len = sizeof(buf);
+        auto ret = get_config_(_backend_handle->backend_handle(), "max_inflight_bytes", buf, &len);
+        if (ret != ResponseCode::Success)
+        {
+            return unbounded;
+        }
+        buf[sizeof(buf) - 1] = '\0';
+        return static_cast<size_t>(std::strtoull(buf, nullptr, 10));
+    }
+    catch (...)
+    {
+        // plugin does not export obj_get_backend_config (e.g. gcs / azure / mock):
+        // dlsym throws for the missing symbol -> treat the window as unbounded
+        return unbounded;
+    }
 }
 
 const utils::Semver min_glibc_semver = utils::Semver(description(static_cast<int>(ResponseCode::GlibcPrerequisite)));

--- a/cpp/common/s3_wrapper/s3_wrapper.cc
+++ b/cpp/common/s3_wrapper/s3_wrapper.cc
@@ -84,8 +84,9 @@ size_t S3ClientWrapper::max_inflight_bytes()
     }
     catch (...)
     {
-        // plugin does not export obj_get_backend_config (e.g. gcs / azure / mock):
-        // dlsym throws for the missing symbol -> treat the window as unbounded
+        // Defensive fallback: all current object-storage plugins (s3 / gcs / azure and the
+        // s3 mock) export obj_get_backend_config, but an older or third-party plugin may not.
+        // dlsym throws for a missing symbol -> treat the window as unbounded.
         return unbounded;
     }
 }

--- a/cpp/common/s3_wrapper/s3_wrapper.h
+++ b/cpp/common/s3_wrapper/s3_wrapper.h
@@ -108,6 +108,11 @@ struct S3ClientWrapper
       common::ResponseCode async_read(const Params & params, backend_api::ObjectRequestId_t request_id, const Range & ranges, char * buffer);
       common::ResponseCode async_read_response(std::vector<backend_api::ObjectCompletionEvent_t> & event_buffer, unsigned max_events_to_retrieve);
 
+      // In-flight window (bytes) the backend advertises for submission throttling, via
+      // obj_get_backend_config("max_inflight_bytes"). Returns SIZE_MAX (unbounded) when
+      // the plugin does not provide the key (e.g. gcs/azure).
+      size_t max_inflight_bytes();
+
       common::ResponseCode list_files(const char* prefix, int is_recursive,
                                       backend_api::ObjectFileEntry_t** out_entries,
                                       unsigned* out_num_entries);

--- a/cpp/gcs/client/client.cc
+++ b/cpp/gcs/client/client.cc
@@ -29,6 +29,12 @@ GCSClient::GCSClient(const common::backend_api::ObjectClientConfig_t& config) :
     _responder(nullptr),
     _chunk_bytesize(config.default_storage_chunk_size)
 {
+    // advertise an in-flight window sized to the async threadpool: margin x pool x chunk,
+    // floored at two chunks so the window can always keep the pool busy
+    _max_inflight_bytes = std::max(
+        static_cast<size_t>(common::backend_api::inflight_window_margin() * _client_config.max_concurrency * _chunk_bytesize),
+        static_cast<size_t>(2) * _chunk_bytesize);
+
     _client = std::make_unique<AsyncGcsClient>(
         _client_config.options, 
         _client_config.max_concurrency,

--- a/cpp/gcs/client/client.h
+++ b/cpp/gcs/client/client.h
@@ -41,10 +41,14 @@ struct GCSClient : common::IClient
     // If stopped before all requests for an async_read() call are sent, subsequent request chunks will not be sent.
     void stop();
 
+    // In-flight window (bytes) advertised to the generic layer: async threadpool size x chunk x margin
+    size_t max_inflight_bytes() const { return _max_inflight_bytes; }
+
  private:
     std::atomic<bool> _stop;
     ClientConfiguration _client_config;
     const size_t _chunk_bytesize;
+    size_t _max_inflight_bytes = 0;
     std::unique_ptr<AsyncGcsClient> _client;
 
     // queue of asynchronous responses

--- a/cpp/gcs/gcs.cc
+++ b/cpp/gcs/gcs.cc
@@ -3,13 +3,24 @@
 #include "common/backend_api/object_storage/list_files_impl.h"
 #include "common/client_mgr/client_mgr.h"
 
+#include <atomic>
+#include <cstdio>
+#include <cstring>
+
 #include "common/exception/exception.h"
+
+#include "utils/logging/logging.h"
 
 namespace runai::llm::streamer::impl::gcs
 {
 
 inline constexpr char GCSClientName[] = "GCS";
 using GCSClientMgr = common::ClientMgr<GCSClient, GCSClientName>;
+
+// In-flight window advertised via obj_get_backend_config("max_inflight_bytes"). Populated
+// when a client is created (GCSClient computes it from its async threadpool size and
+// default_storage_chunk_size). Uniform across clients in a process; SIZE_MAX = unset/unbounded.
+static std::atomic<size_t> g_max_inflight_bytes{static_cast<size_t>(-1)};
 
 common::backend_api::ResponseCode_t obj_open_backend(common::backend_api::ObjectBackendHandle_t* out_backend_handle)
 {
@@ -27,6 +38,51 @@ common::backend_api::ObjectShutdownPolicy_t obj_get_backend_shutdown_policy()
     return common::backend_api::OBJECT_SHUTDOWN_POLICY_ON_PROCESS_EXIT;
 }
 
+common::backend_api::ResponseCode_t obj_get_backend_config(common::backend_api::ObjectBackendHandle_t /* backend_handle */,
+                                                           const char* key,
+                                                           char* out_value_buffer,
+                                                           unsigned int* in_out_buffer_len)
+{
+    try
+    {
+        if (!key || !out_value_buffer || !in_out_buffer_len)
+        {
+            LOG(ERROR) << "obj_get_backend_config called with null argument(s)";
+            return common::ResponseCode::UnknownError;
+        }
+
+        if (std::strcmp(key, "max_inflight_bytes") == 0)
+        {
+            char tmp[32];
+            const int n = std::snprintf(tmp, sizeof(tmp), "%zu", g_max_inflight_bytes.load());
+            if (n < 0 || n >= static_cast<int>(sizeof(tmp)))
+            {
+                LOG(ERROR) << "Failed to format max_inflight_bytes value";
+                return common::ResponseCode::UnknownError;
+            }
+            const unsigned int needed = static_cast<unsigned int>(n) + 1;   // including null terminator
+            if (*in_out_buffer_len < needed)
+            {
+                LOG(ERROR) << "obj_get_backend_config buffer too small for key '" << key
+                           << "': need " << needed << " bytes, have " << *in_out_buffer_len;
+                *in_out_buffer_len = needed;   // report required size to the caller
+                return common::ResponseCode::UnknownError;
+            }
+            std::memcpy(out_value_buffer, tmp, needed);
+            *in_out_buffer_len = static_cast<unsigned int>(n);   // written length, excluding null terminator
+            return common::ResponseCode::Success;
+        }
+
+        LOG(WARNING) << "Unknown backend config key: " << key;
+        return common::ResponseCode::UnknownError;
+    }
+    catch(const std::exception& e)
+    {
+        LOG(ERROR) << "Caught exception in obj_get_backend_config";
+    }
+    return common::ResponseCode::UnknownError;
+}
+
 common::backend_api::ResponseCode_t obj_create_client(common::backend_api::ObjectBackendHandle_t backend_handle,
                                                        const common::backend_api::ObjectClientConfig_t* client_initial_config,
                                                        common::backend_api::ObjectClientHandle_t* out_client_handle)
@@ -35,6 +91,7 @@ common::backend_api::ResponseCode_t obj_create_client(common::backend_api::Objec
     try
     {
         *out_client_handle = GCSClientMgr::pop(*client_initial_config);
+        g_max_inflight_bytes.store(static_cast<GCSClient *>(*out_client_handle)->max_inflight_bytes());
     }
     catch(const common::Exception & e)
     {

--- a/cpp/gcs/gcs.cc
+++ b/cpp/gcs/gcs.cc
@@ -78,7 +78,7 @@ common::backend_api::ResponseCode_t obj_get_backend_config(common::backend_api::
     }
     catch(const std::exception& e)
     {
-        LOG(ERROR) << "Caught exception in obj_get_backend_config";
+        LOG(ERROR) << "Caught exception in obj_get_backend_config: " << e.what();
     }
     return common::ResponseCode::UnknownError;
 }

--- a/cpp/gcs/gcs.h
+++ b/cpp/gcs/gcs.h
@@ -12,6 +12,13 @@ namespace runai::llm::streamer::impl::gcs
 extern "C" common::backend_api::ResponseCode_t obj_open_backend(common::backend_api::ObjectBackendHandle_t* out_backend_handle);
 extern "C" common::backend_api::ResponseCode_t obj_close_backend(common::backend_api::ObjectBackendHandle_t backend_handle);
 extern "C" common::backend_api::ObjectShutdownPolicy_t obj_get_backend_shutdown_policy();
+
+extern "C" common::backend_api::ResponseCode_t obj_get_backend_config(
+    common::backend_api::ObjectBackendHandle_t backend_handle,
+    const char* key,
+    char* out_value_buffer,
+    unsigned int* in_out_buffer_len
+);
 // --- Client API ---
 
 extern "C" common::backend_api::ResponseCode_t obj_create_client(

--- a/cpp/gcs/gcs.ldscript
+++ b/cpp/gcs/gcs.ldscript
@@ -9,6 +9,7 @@
         obj_cancel_all_reads;
         obj_remove_all_clients;
         obj_get_backend_shutdown_policy;
+        obj_get_backend_config;
         obj_list_files;
         obj_free_file_list;
     local: *;

--- a/cpp/s3/client/client.cc
+++ b/cpp/s3/client/client.cc
@@ -218,6 +218,11 @@ S3Client::S3Client(const common::backend_api::ObjectClientConfig_t & config) :
         LOG(DEBUG) << "Creating S3 client with given credentials";
         _client = std::make_unique<Aws::S3Crt::S3CrtClient>(*_client_credentials, _client_config.config);
     }
+
+    // Compute the in-flight window from the already-configured chunk size
+    // (default_storage_chunk_size, stored as _chunk_bytesize) and the effective
+    // throughputTargetGbps - no env re-reading of the chunk size.
+    _max_inflight_bytes = inflight_window_bytes(_chunk_bytesize, _client_config.config.throughputTargetGbps);
 }
 
 // returns response object that contains the index of the range in ranges vector  which was passed in the request (0... number of ranges - 1)
@@ -248,82 +253,49 @@ common::backend_api::ResponseCode_t S3Client::async_read(const char* path,
     }
 
     const auto uri = common::s3::StorageUri(path);
-
     Aws::String bucket_name(uri.bucket);
     Aws::String path_name(uri.path);
 
-    char * buffer_ = destination_buffer;
-    // split range into chunks
-    size_t size = std::max(1UL, range.length/_chunk_bytesize);
-    LOG(SPAM) <<"Number of chunks is " << size;
+    // The caller (worker) already split the object into chunks and manages the in-flight
+    // window; submit this chunk as a single ranged GET and report exactly one completion
+    // for it. request_id is a unique per-chunk id - the worker maps it back to the owning
+    // task and reports the task done once all of its chunks have completed.
+    char * buffer = destination_buffer;
+    const size_t bytesize = range.length;
 
-    // each range is divided into chunks (size is the number of chunks)
-    // when all the chunks have been read successfuly the response for that range is pushed to the responder
+    auto request = std::make_shared<Aws::S3Crt::Model::GetObjectRequest>();
+    request->SetBucket(bucket_name);
+    request->SetKey(path_name);
+    std::string range_str = "bytes=" + std::to_string(range.offset) + "-" + std::to_string(range.offset + bytesize - 1);
+    request->SetRange(range_str.c_str());
 
-    auto counter = std::make_shared< std::atomic<unsigned> >(size);
-    // success flag for the current range is passed to the client
-    auto is_success = std::make_shared< std::atomic<bool> >(true);
+    request->SetResponseStreamFactory(
+        [buffer, bytesize]()
+        {
+            std::unique_ptr<Aws::StringStream>
+                    stream(Aws::New<Aws::StringStream>("RunaiBuffer"));
 
-    size_t total_ = range.length;
-    size_t offset_ = range.offset;
-    for (unsigned i = 0; i < size && !_stop; ++i)
-    {
-        size_t bytesize_ = (i == size - 1 ? total_ : _chunk_bytesize);
+            stream->rdbuf()->pubsetbuf(buffer, bytesize);
 
-        // send async request
-        auto request = std::make_shared<Aws::S3Crt::Model::GetObjectRequest>();
-
-        request->SetBucket(bucket_name);
-        request->SetKey(path_name);
-        std::string range_str = "bytes=" + std::to_string(offset_) + "-" + std::to_string(offset_ + bytesize_ - 1);
-        request->SetRange(range_str.c_str());
-
-        request->SetResponseStreamFactory(
-            [buffer_, bytesize_]()
-            {
-                std::unique_ptr<Aws::StringStream>
-                        stream(Aws::New<Aws::StringStream>("RunaiBuffer"));
-
-                stream->rdbuf()->pubsetbuf(buffer_, bytesize_);
-
-                return stream.release();
-            });
-
-        _client->GetObjectAsync(*request, [request, responder = _responder, request_id, counter, is_success](const Aws::S3Crt::S3CrtClient*, const Aws::S3Crt::Model::GetObjectRequest&,
-                                                                        const Aws::S3Crt::Model::GetObjectOutcome& outcome,
-                                                                        const std::shared_ptr<const Aws::Client::AsyncCallerContext>&) {
-            if (outcome.IsSuccess())
-            {
-                const auto running = counter->fetch_sub(1);
-                LOG(SPAM) << "Async read request " << request_id << " succeeded - " << running << " running";
-                // send success response only if all the requests have succeeded
-                // note that unsuccessful attempts do not update the counter
-                if (running == 1)
-                {
-                    common::backend_api::Response r(request_id, common::ResponseCode::Success);
-                    responder->push(std::move(r));
-                }
-            }
-            else
-            {
-                // Note: currently a failure to read any sub range fails the entire read request
-                //       a retry mechanism should be added for failed reads
-                bool previous = is_success->exchange(false);
-                // send error response only once
-                if (previous)
-                {
-                    const auto & err = outcome.GetError();
-                    LOG(ERROR) << "Failed to download s3 object of request " << request_id << " " << err.GetExceptionName() << ": " << err.GetMessage();
-                    common::backend_api::Response r(request_id, common::ResponseCode::FileAccessError);
-                    responder->push(std::move(r));
-                }
-            }
+            return stream.release();
         });
 
-        total_ -= bytesize_;
-        offset_ += bytesize_;
-        buffer_ += bytesize_;
-    }
+    _client->GetObjectAsync(*request, [request, responder = _responder, request_id](const Aws::S3Crt::S3CrtClient*, const Aws::S3Crt::Model::GetObjectRequest&,
+                                                                    const Aws::S3Crt::Model::GetObjectOutcome& outcome,
+                                                                    const std::shared_ptr<const Aws::Client::AsyncCallerContext>&) {
+        if (outcome.IsSuccess())
+        {
+            LOG(SPAM) << "Async read chunk of request " << request_id << " succeeded";
+            responder->push(common::backend_api::Response(request_id, common::ResponseCode::Success));
+        }
+        else
+        {
+            // Note: a failed chunk fails the whole read request; a retry mechanism could be added
+            const auto & err = outcome.GetError();
+            LOG(ERROR) << "Failed to download s3 object of request " << request_id << " " << err.GetExceptionName() << ": " << err.GetMessage();
+            responder->push(common::backend_api::Response(request_id, common::ResponseCode::FileAccessError));
+        }
+    });
 
     return _stop ? common::ResponseCode::FinishedError : common::ResponseCode::Success;
 }

--- a/cpp/s3/client/client.cc
+++ b/cpp/s3/client/client.cc
@@ -280,11 +280,23 @@ common::backend_api::ResponseCode_t S3Client::async_read(const char* path,
             return stream.release();
         });
 
-    _client->GetObjectAsync(*request, [request, responder = _responder, request_id](const Aws::S3Crt::S3CrtClient*, const Aws::S3Crt::Model::GetObjectRequest&,
+    _client->GetObjectAsync(*request, [request, responder = _responder, request_id, bytesize](const Aws::S3Crt::S3CrtClient*, const Aws::S3Crt::Model::GetObjectRequest&,
                                                                     const Aws::S3Crt::Model::GetObjectOutcome& outcome,
                                                                     const std::shared_ptr<const Aws::Client::AsyncCallerContext>&) {
         if (outcome.IsSuccess())
         {
+            // A success outcome does not guarantee the body matched the requested range: a
+            // mis-serving endpoint (e.g. a 200 full-object response instead of a 206 partial)
+            // can under- or over-fill the caller's fixed buffer, leaving stale bytes in the
+            // tail. Verify the reported length before reporting the chunk done.
+            const long long content_length = outcome.GetResult().GetContentLength();
+            if (content_length != static_cast<long long>(bytesize))
+            {
+                LOG(ERROR) << "Async read chunk of request " << request_id << " returned "
+                           << content_length << " bytes, expected " << bytesize;
+                responder->push(common::backend_api::Response(request_id, common::ResponseCode::FileTruncatedError));
+                return;
+            }
             LOG(SPAM) << "Async read chunk of request " << request_id << " succeeded";
             responder->push(common::backend_api::Response(request_id, common::ResponseCode::Success));
         }

--- a/cpp/s3/client/client.h
+++ b/cpp/s3/client/client.h
@@ -71,12 +71,19 @@ struct S3Client : S3ClientBase
     // The S3CrtClient d'tor will wait for response of all teh sent requests, which can take a while
     void stop();
 
+    // In-flight submission window (bytes) for this client: a bandwidth-delay product from
+    // the configured chunk size (ObjectClientConfig_t.default_storage_chunk_size) and the
+    // target throughput (throughputTargetGbps). Surfaced to the generic layer via the
+    // backend config query.
+    size_t max_inflight_bytes() const { return _max_inflight_bytes; }
+
     using S3ClientBase::verify_credentials;
 
  private:
     std::atomic<bool> _stop;
     ClientConfiguration _client_config;
     std::unique_ptr<Aws::S3Crt::S3CrtClient> _client;
+    size_t _max_inflight_bytes = 0;
 
     // queue of asynchronous responses
     using Responder = common::SharedQueue<common::backend_api::Response>;

--- a/cpp/s3/client_configuration/BUILD
+++ b/cpp/s3/client_configuration/BUILD
@@ -5,6 +5,7 @@ runai_cc_auto_library(
     deps = [
         "@aws",
         "//common/storage_uri",
+        "//common/backend_api/object_storage",
         "//utils/env",
         "//utils/logging",
     ],

--- a/cpp/s3/client_configuration/client_configuration.cc
+++ b/cpp/s3/client_configuration/client_configuration.cc
@@ -1,10 +1,38 @@
 #include "s3/client_configuration/client_configuration.h"
 
+#include <algorithm>
+
+#include "common/backend_api/object_storage/object_storage.h"
 #include "utils/logging/logging.h"
 #include "utils/env/env.h"
 
 namespace runai::llm::streamer::impl::s3
 {
+
+size_t inflight_window_bytes(size_t chunk_bytesize, double target_gbps)
+{
+    // explicit override, in MiB
+    const size_t mib = utils::getenv<unsigned long>("RUNAI_STREAMER_S3_MAX_INFLIGHT_MIB", 0);
+    if (mib != 0)
+    {
+        const size_t result = mib * 1024 * 1024;
+        LOG(INFO) << "S3 in-flight window: " << utils::logging::human_readable_size(result) << " (RUNAI_STREAMER_S3_MAX_INFLIGHT_MIB=" << mib << ")";
+        return result;
+    }
+
+    // otherwise derive a bandwidth-delay product from the target throughput, floored at a
+    // couple of read chunks so the window can always keep the pipe busy. chunk_bytesize is
+    // the client's configured default_storage_chunk_size; target_gbps is throughputTargetGbps.
+    const double bytes_per_sec = target_gbps * 1e9 / 8.0;   // Gbps (gigabits) -> bytes/s
+    const double nominal_latency_s = 0.1;                   // ~100 ms
+    const double margin = common::backend_api::inflight_window_margin();
+    const size_t window = static_cast<size_t>(bytes_per_sec * nominal_latency_s * margin);
+
+    const size_t result = std::max(window, 2 * chunk_bytesize);
+    LOG(DEBUG) << "S3 in-flight window: " << utils::logging::human_readable_size(result)
+              << " (target throughput " << target_gbps << " Gbps, chunk " << utils::logging::human_readable_size(chunk_bytesize) << ")";
+    return result;
+}
 
 ClientConfiguration::ClientConfiguration()
 {

--- a/cpp/s3/client_configuration/client_configuration.h
+++ b/cpp/s3/client_configuration/client_configuration.h
@@ -5,10 +5,18 @@
 #include <aws/s3-crt/model/BucketLocationConstraint.h>
 
 
+#include <cstddef>
+
 #include "common/storage_uri/storage_uri.h"
 
 namespace runai::llm::streamer::impl::s3
 {
+
+// In-flight window (bytes) for object-storage submission: a bandwidth-delay product from
+// the target throughput (target_gbps, i.e. throughputTargetGbps), floored at a couple of
+// chunk_bytesize (the client's default_storage_chunk_size). RUNAI_STREAMER_S3_MAX_INFLIGHT_MIB
+// (in MiB) overrides it directly.
+size_t inflight_window_bytes(size_t chunk_bytesize, double target_gbps);
 
 struct ClientConfiguration
 {

--- a/cpp/s3/s3.cc
+++ b/cpp/s3/s3.cc
@@ -128,7 +128,7 @@ common::backend_api::ResponseCode_t obj_get_backend_config(common::backend_api::
     }
     catch(const std::exception& e)
     {
-        LOG(ERROR) << "Caught exception in obj_get_backend_config";
+        LOG(ERROR) << "Caught exception in obj_get_backend_config: " << e.what();
     }
     return common::ResponseCode::UnknownError;
 }

--- a/cpp/s3/s3.cc
+++ b/cpp/s3/s3.cc
@@ -2,6 +2,10 @@
 #include "s3/s3_init/s3_init.h"
 #include "s3/client/client.h"
 
+#include <atomic>
+#include <cstdio>
+#include <cstring>
+
 #include "common/backend_api/object_storage/list_files_impl.h"
 #include "common/client_mgr/client_mgr.h"
 #include "common/exception/exception.h"
@@ -29,6 +33,11 @@ namespace runai::llm::streamer::impl::s3
 
 inline constexpr char S3ClientName[] = "S3";
 using S3ClientMgr = common::ClientMgr<S3Client, S3ClientName>;
+
+// In-flight window advertised via obj_get_backend_config("max_inflight_bytes"). Populated
+// when a client is created (S3Client computes it from default_storage_chunk_size and
+// throughputTargetGbps). Uniform across clients in a process; SIZE_MAX = unset/unbounded.
+static std::atomic<size_t> g_max_inflight_bytes{static_cast<size_t>(-1)};
 
 // --- Backend API ---
 
@@ -79,6 +88,51 @@ common::backend_api::ObjectShutdownPolicy_t obj_get_backend_shutdown_policy()
     return common::backend_api::OBJECT_SHUTDOWN_POLICY_ON_PROCESS_EXIT;
 }
 
+common::backend_api::ResponseCode_t obj_get_backend_config(common::backend_api::ObjectBackendHandle_t /* backend_handle */,
+                                                           const char* key,
+                                                           char* out_value_buffer,
+                                                           unsigned int* in_out_buffer_len)
+{
+    try
+    {
+        if (!key || !out_value_buffer || !in_out_buffer_len)
+        {
+            LOG(ERROR) << "obj_get_backend_config called with null argument(s)";
+            return common::ResponseCode::UnknownError;
+        }
+
+        if (std::strcmp(key, "max_inflight_bytes") == 0)
+        {
+            char tmp[32];
+            const int n = std::snprintf(tmp, sizeof(tmp), "%zu", g_max_inflight_bytes.load());
+            if (n < 0 || n >= static_cast<int>(sizeof(tmp)))
+            {
+                LOG(ERROR) << "Failed to format max_inflight_bytes value";
+                return common::ResponseCode::UnknownError;
+            }
+            const unsigned int needed = static_cast<unsigned int>(n) + 1;   // including null terminator
+            if (*in_out_buffer_len < needed)
+            {
+                LOG(ERROR) << "obj_get_backend_config buffer too small for key '" << key
+                           << "': need " << needed << " bytes, have " << *in_out_buffer_len;
+                *in_out_buffer_len = needed;   // report required size to the caller
+                return common::ResponseCode::UnknownError;
+            }
+            std::memcpy(out_value_buffer, tmp, needed);
+            *in_out_buffer_len = static_cast<unsigned int>(n);   // written length, excluding null terminator
+            return common::ResponseCode::Success;
+        }
+
+        LOG(WARNING) << "Unknown backend config key: " << key;
+        return common::ResponseCode::UnknownError;
+    }
+    catch(const std::exception& e)
+    {
+        LOG(ERROR) << "Caught exception in obj_get_backend_config";
+    }
+    return common::ResponseCode::UnknownError;
+}
+
 // --- Client API ---
 
 common::backend_api::ResponseCode_t obj_create_client(common::backend_api::ObjectBackendHandle_t backend_handle,
@@ -89,6 +143,7 @@ common::backend_api::ResponseCode_t obj_create_client(common::backend_api::Objec
     try
     {
         *out_client_handle = S3ClientMgr::pop(*client_initial_config);
+        g_max_inflight_bytes.store(static_cast<S3Client *>(*out_client_handle)->max_inflight_bytes());
     }
     catch(const std::exception & e)
     {

--- a/cpp/s3/s3.h
+++ b/cpp/s3/s3.h
@@ -37,6 +37,15 @@ namespace runai::llm::streamer::impl::s3
 extern "C" common::backend_api::ResponseCode_t obj_open_backend(common::backend_api::ObjectBackendHandle_t* out_backend_handle);
 extern "C" common::backend_api::ResponseCode_t obj_close_backend(common::backend_api::ObjectBackendHandle_t backend_handle);
 extern "C" common::backend_api::ObjectShutdownPolicy_t obj_get_backend_shutdown_policy();
+
+// Query a backend-wide configuration value by key. Currently supports
+// "max_inflight_bytes" (the S3 in-flight submission window, bytes).
+extern "C" common::backend_api::ResponseCode_t obj_get_backend_config(
+    common::backend_api::ObjectBackendHandle_t backend_handle,
+    const char* key,
+    char* out_value_buffer,
+    unsigned int* in_out_buffer_len);
+
 // --- Client API ---
 
 extern "C" common::backend_api::ResponseCode_t obj_create_client(

--- a/cpp/s3/s3.ldscript
+++ b/cpp/s3/s3.ldscript
@@ -9,6 +9,7 @@
         obj_cancel_all_reads;
         obj_remove_all_clients;
         obj_get_backend_shutdown_policy;
+        obj_get_backend_config;
         obj_list_files;
         obj_free_file_list;
     local: *;

--- a/cpp/s3/s3_mock/s3_mock.cc
+++ b/cpp/s3/s3_mock/s3_mock.cc
@@ -28,6 +28,24 @@ unsigned __mock_response_time_ms = 0;
 std::mutex __mutex;
 std::atomic<bool> __stopped(false);
 std::atomic<bool> __opened(false);
+// in-flight window (bytes) reported by obj_get_backend_config("max_inflight_bytes").
+// default SIZE_MAX = unbounded (no window); set via runai_mock_s3_set_inflight_window.
+std::atomic<size_t> __mock_max_inflight_bytes{static_cast<size_t>(-1)};
+// peak per-client in-flight (submitted-but-not-completed) request count, for window tests
+std::atomic<size_t> __mock_max_concurrent{0};
+// requests whose path matched __mock_failing_path at submission time; their completion
+// events are reported with FileAccessError instead of the global response code, for
+// per-file error-isolation tests. __mock_failing_path is a substring match; empty = none.
+std::string __mock_failing_path;
+std::set<common::backend_api::ObjectRequestId_t> __mock_failing_requests;
+// peak number of completion events returned by a single obj_wait_for_completions call,
+// for batch (max_responses > 1) tests
+std::atomic<size_t> __mock_max_events_per_wait{0};
+// when set, obj_wait_for_completions appends a FinishedError sentinel event (handle 0) once
+// the ready requests are drained - mimicking the azure/gcs plugins, which pop their responder
+// up to max_events and emit the SharedQueue "finished" sentinel. Used to test that the worker
+// tolerates the sentinel rather than treating handle 0 as an unknown completion.
+std::atomic<bool> __mock_append_finished_sentinel{false};
 common::backend_api::ObjectShutdownPolicy_t __shutdown_policy = common::backend_api::OBJECT_SHUTDOWN_POLICY_ON_PROCESS_EXIT;
 
 std::vector<std::pair<std::string, size_t>> __mock_files;
@@ -86,10 +104,63 @@ common::backend_api::ObjectShutdownPolicy_t obj_get_backend_shutdown_policy()
     return __shutdown_policy;
 }
 
+common::backend_api::ResponseCode_t obj_get_backend_config(common::backend_api::ObjectBackendHandle_t /* backend_handle */,
+                                                           const char* key,
+                                                           char* out_value_buffer,
+                                                           unsigned int* in_out_buffer_len)
+{
+    if (!key || !out_value_buffer || !in_out_buffer_len)
+    {
+        return common::ResponseCode::UnknownError;
+    }
+
+    if (std::strcmp(key, "max_inflight_bytes") == 0)
+    {
+        const std::string value = std::to_string(__mock_max_inflight_bytes.load());
+        const unsigned int needed = static_cast<unsigned int>(value.size()) + 1;   // including null terminator
+        if (*in_out_buffer_len < needed)
+        {
+            *in_out_buffer_len = needed;
+            return common::ResponseCode::UnknownError;
+        }
+        std::memcpy(out_value_buffer, value.c_str(), needed);
+        *in_out_buffer_len = static_cast<unsigned int>(value.size());
+        return common::ResponseCode::Success;
+    }
+
+    return common::ResponseCode::UnknownError;
+}
+
 void runai_mock_s3_set_response_time_ms(unsigned milliseconds)
 {
     const auto guard = std::unique_lock<std::mutex>(__mutex);
     __mock_response_time_ms = milliseconds;
+}
+
+void runai_mock_s3_set_inflight_window(size_t bytes)
+{
+    __mock_max_inflight_bytes.store(bytes);
+}
+
+size_t runai_mock_s3_max_concurrent()
+{
+    return __mock_max_concurrent.load();
+}
+
+void runai_mock_s3_set_failing_path(const char* substr)
+{
+    const auto guard = std::unique_lock<std::mutex>(__mutex);
+    __mock_failing_path = (substr != nullptr) ? substr : "";
+}
+
+size_t runai_mock_s3_max_events_per_wait()
+{
+    return __mock_max_events_per_wait.load();
+}
+
+void runai_mock_s3_set_append_finished_sentinel(bool enabled)
+{
+    __mock_append_finished_sentinel.store(enabled);
 }
 
 common::backend_api::ResponseCode_t obj_create_client(
@@ -177,6 +248,19 @@ common::backend_api::ResponseCode_t obj_request_read(
     ASSERT(__mock_client_requests.find(client_handle) != __mock_client_requests.end()) << "Client " << client_handle << " not found";
     __mock_client_requests[client_handle].insert(request_id);
 
+    // mark this request to fail at completion if its path matches the configured failing path
+    if (!__mock_failing_path.empty() && path != nullptr && std::string(path).find(__mock_failing_path) != std::string::npos)
+    {
+        __mock_failing_requests.insert(request_id);
+    }
+
+    // track peak per-client in-flight (submitted-but-not-completed) for window tests
+    const size_t inflight = __mock_client_requests[client_handle].size();
+    if (inflight > __mock_max_concurrent.load())
+    {
+        __mock_max_concurrent.store(inflight);
+    }
+
     return r;
 }
 
@@ -235,11 +319,28 @@ common::backend_api::ResponseCode_t obj_wait_for_completions(common::backend_api
     *out_num_events_retrieved = 0;
     for (auto it = client_requests.begin(); it != client_requests.end() && *out_num_events_retrieved < max_events_to_retrieve; )
     {
+        // a request marked via runai_mock_s3_set_failing_path fails; others get the global code
+        auto code = (__mock_failing_requests.erase(*it) != 0) ? common::ResponseCode::FileAccessError : r;
         event_buffer[*out_num_events_retrieved].request_id = *it;
-        event_buffer[*out_num_events_retrieved].response_code = r;
+        event_buffer[*out_num_events_retrieved].response_code = code;
         it = client_requests.erase(it);
         ++*out_num_events_retrieved;
     }
+    // track the peak count of real completions per wait (before any sentinel), for batch tests
+    if (*out_num_events_retrieved > __mock_max_events_per_wait.load())
+    {
+        __mock_max_events_per_wait.store(*out_num_events_retrieved);
+    }
+
+    // mimic azure/gcs: once ready requests are drained, append a FinishedError sentinel event
+    // (handle 0) if the buffer still has room - the worker must tolerate this
+    if (__mock_append_finished_sentinel.load() && *out_num_events_retrieved < max_events_to_retrieve)
+    {
+        event_buffer[*out_num_events_retrieved].request_id = 0;
+        event_buffer[*out_num_events_retrieved].response_code = common::ResponseCode::FinishedError;
+        ++*out_num_events_retrieved;
+    }
+
     if (*out_num_events_retrieved == 0)
     {
         LOG(DEBUG) << "No more ranges to return";
@@ -353,9 +454,15 @@ void runai_mock_s3_cleanup()
 {
     runai_mock_s3_set_response_time_ms(0);
     __stopped = false;
+    __mock_max_inflight_bytes.store(static_cast<size_t>(-1));
+    __mock_max_concurrent.store(0);
+    __mock_max_events_per_wait.store(0);
+    __mock_append_finished_sentinel.store(false);
     runai_s3_mock_set_backend_shutdown_policy(common::backend_api::OBJECT_SHUTDOWN_POLICY_ON_PROCESS_EXIT);
 
     const auto guard = std::unique_lock<std::mutex>(__mutex);
+    __mock_failing_path.clear();
+    __mock_failing_requests.clear();
     __mock_files.clear();
     __mock_list_files_response = common::ResponseCode::Success;
     __mock_last_list_files_is_recursive = -1;

--- a/cpp/s3/s3_mock/s3_mock.h
+++ b/cpp/s3/s3_mock/s3_mock.h
@@ -14,6 +14,11 @@ namespace runai::llm::streamer::common::s3
 extern "C" common::backend_api::ResponseCode_t obj_open_backend(common::backend_api::ObjectBackendHandle_t* out_backend_handle);
 extern "C" common::backend_api::ResponseCode_t obj_close_backend(common::backend_api::ObjectBackendHandle_t backend_handle);
 extern "C" common::backend_api::ObjectShutdownPolicy_t obj_get_backend_shutdown_policy();
+extern "C" common::backend_api::ResponseCode_t obj_get_backend_config(
+    common::backend_api::ObjectBackendHandle_t backend_handle,
+    const char* key,
+    char* out_value_buffer,
+    unsigned int* in_out_buffer_len);
 // --- Client API ---
 
 extern "C" common::backend_api::ResponseCode_t obj_create_client(
@@ -64,6 +69,17 @@ extern "C" void runai_mock_s3_set_list_files_response(common::backend_api::Respo
 extern "C" int runai_mock_s3_last_list_files_is_recursive();
 
 extern "C" void runai_mock_s3_set_response_time_ms(unsigned milliseconds);
+// Sets the in-flight window (bytes) reported by obj_get_backend_config("max_inflight_bytes").
+extern "C" void runai_mock_s3_set_inflight_window(size_t bytes);
+// Peak per-client in-flight (submitted-but-not-completed) request count observed since the last cleanup.
+extern "C" size_t runai_mock_s3_max_concurrent();
+// Fail (with FileAccessError) the completion of any read whose path contains substr; "" / nullptr disables.
+extern "C" void runai_mock_s3_set_failing_path(const char* substr);
+// Peak number of completion events returned by a single obj_wait_for_completions call since the last cleanup.
+extern "C" size_t runai_mock_s3_max_events_per_wait();
+// When enabled, obj_wait_for_completions appends a FinishedError sentinel event (handle 0) after the
+// ready completions, mimicking the azure/gcs plugins' responder-drain behavior.
+extern "C" void runai_mock_s3_set_append_finished_sentinel(bool enabled);
 extern "C" void runai_s3_mock_set_backend_shutdown_policy(common::backend_api::ObjectShutdownPolicy_t policy);
 extern "C" int runai_mock_s3_clients();
 extern "C" void runai_mock_s3_cleanup();

--- a/cpp/s3/s3_mock/s3_mock.ldscript
+++ b/cpp/s3/s3_mock/s3_mock.ldscript
@@ -2,6 +2,11 @@
     global:
         runai_mock_s3_clients;
         runai_mock_s3_set_response_time_ms;
+        runai_mock_s3_set_inflight_window;
+        runai_mock_s3_max_concurrent;
+        runai_mock_s3_set_failing_path;
+        runai_mock_s3_max_events_per_wait;
+        runai_mock_s3_set_append_finished_sentinel;
         runai_mock_s3_cleanup;
         runai_s3_mock_set_backend_shutdown_policy;
         runai_mock_s3_is_shutdown;
@@ -19,6 +24,7 @@
         obj_cancel_all_reads;
         obj_remove_all_clients;
         obj_get_backend_shutdown_policy;
+        obj_get_backend_config;
 
     local: *;
 };

--- a/cpp/streamer/impl/batch/batch.cc
+++ b/cpp/streamer/impl/batch/batch.cc
@@ -42,14 +42,6 @@ size_t Batch::end_offset() const
     return range.end;
 }
 
-void Batch::request(std::shared_ptr<Reader> reader, std::atomic<bool> & stopped)
-{
-    ASSERT(reader != nullptr) << "Reader is not initialized";
-    ASSERT(is_object_storage()) << "S3 params are not initialized";
-
-    request_async_read(reader.get(), stopped);
-}
-
 void Batch::execute(std::atomic<bool> & stopped)
 {
     LOG(DEBUG) << "Start reading from file " << path;
@@ -148,31 +140,6 @@ void Batch::read(const Config & config, std::atomic<bool> & stopped)
     if (stopped)
     {
         throw common::Exception(common::ResponseCode::FinishedError);
-    }
-}
-
-void Batch::request_async_read(Reader * reader, std::atomic<bool> & stopped)
-{
-    if (stopped)
-    {
-        throw common::Exception(common::ResponseCode::FinishedError);
-    }
-
-    // For CPU buffer we assume that all the requests are written to a single continous buffer
-
-    // request asynchronous read for each task
-    for (auto & task : tasks)
-    {
-        auto dst = task.destination();
-        common::Range range(task.info.offset, task.info.bytesize);
-        if (range.size == 0)
-        {
-            // tensors of size zero are valid, but empty request can be invalid in the storage backend
-            LOG(DEBUG) << "Found task of zero size - return response and don't pass to backend";
-            handle_task_response(common::ResponseCode::Success, &task);
-            continue;
-        }
-        reader->async_read(object_storage_params, task.info.global_id, range, dst);
     }
 }
 

--- a/cpp/streamer/impl/batch/batch.h
+++ b/cpp/streamer/impl/batch/batch.h
@@ -67,9 +67,6 @@ struct Batch
   // read the batch synchronously
   void execute(std::atomic<bool> & stopped);
 
-  // request the batch asynchronously
-  void request(std::shared_ptr<Reader> reader, std::atomic<bool> & stopped);
-
   // handle response from the reader
   void handle_response(const common::backend_api::Response & response, const Task * task_ptr);
 
@@ -102,10 +99,6 @@ struct Batch
 
  private:
   void read(const Config & config, std::atomic<bool> & stopped);
-
-  void async_wait(Reader * reader, std::atomic<bool> & stopped);
-
-  void request_async_read(Reader * reader, std::atomic<bool> & stopped);
 
   // handle response from a single task
   void handle_task_response(const common::ResponseCode response_code, const Task * task_ptr);

--- a/cpp/streamer/impl/reader/reader.h
+++ b/cpp/streamer/impl/reader/reader.h
@@ -34,6 +34,10 @@ struct Reader
     virtual void async_read(const common::s3::S3ClientWrapper::Params & params, common::backend_api::ObjectRequestId_t request_handle, const common::Range & range, char * buffer) = 0;
     virtual common::ResponseCode async_response(std::vector<common::backend_api::Response> & responses, unsigned max_responses) = 0;
 
+    // In-flight window (bytes) the backend advertises for submission throttling.
+    // Default is unbounded; object-storage readers override it with the plugin value.
+    virtual size_t max_inflight_bytes() const { return static_cast<size_t>(-1); }
+
     const Mode mode;
 };
 

--- a/cpp/streamer/impl/s3/s3.cc
+++ b/cpp/streamer/impl/s3/s3.cc
@@ -57,6 +57,11 @@ common::ResponseCode S3::async_response(std::vector<common::backend_api::Respons
     return common::ResponseCode::Success;
 }
 
+size_t S3::max_inflight_bytes() const
+{
+    return _client->max_inflight_bytes();
+}
+
 S3Cleanup::~S3Cleanup()
 {
     try

--- a/cpp/streamer/impl/s3/s3.h
+++ b/cpp/streamer/impl/s3/s3.h
@@ -35,6 +35,8 @@ struct S3 : Reader
     void async_read(const common::s3::S3ClientWrapper::Params & params, common::backend_api::ObjectRequestId_t request_handle, const common::Range & range, char * buffer) override;
     common::ResponseCode async_response(std::vector<common::backend_api::Response> & responses, unsigned max_responses) override;
 
+    size_t max_inflight_bytes() const override;
+
  private:
     std::shared_ptr<common::s3::S3ClientWrapper> _client;
     const Config & _config;

--- a/cpp/streamer/impl/workload/BUILD
+++ b/cpp/streamer/impl/workload/BUILD
@@ -4,6 +4,7 @@ runai_cc_auto_library(
     name = "workload",
     deps = [
         "//utils/logging",
+        "//utils/env",
         "//utils/capacity_queue",
         "//common/s3_wrapper",
         "//common/exception",

--- a/cpp/streamer/impl/workload/BUILD
+++ b/cpp/streamer/impl/workload/BUILD
@@ -4,6 +4,7 @@ runai_cc_auto_library(
     name = "workload",
     deps = [
         "//utils/logging",
+        "//utils/capacity_queue",
         "//common/s3_wrapper",
         "//common/exception",
         "//common/response_code",

--- a/cpp/streamer/impl/workload/workload.cc
+++ b/cpp/streamer/impl/workload/workload.cc
@@ -16,6 +16,7 @@
 #include "common/backend_api/response/response.h"
 
 #include "utils/capacity_queue/capacity_queue.h"
+#include "utils/env/env.h"
 #include "utils/logging/logging.h"
 
 namespace runai::llm::streamer::impl
@@ -288,9 +289,11 @@ void Workload::async_read(std::atomic<bool> & stopped)
         // prime the window, then refill as completions free credit
         pump();
 
-        // request completions in batches; the reader may return several ready completions per
-        // call (max_responses > 1), each handled independently below
-        const unsigned max_responses = 64;
+        // Request one completion at a time by default for prompt, per-completion window refill.
+        // The drain loop handles a batch of several responses correctly (and tolerates the
+        // drained-responder sentinel), so RUNAI_STREAMER_INTERNAL_MAX_RESPONSES can raise this to
+        // reduce wait() calls at the cost of refill granularity (internal tuning / test knob).
+        const unsigned max_responses = static_cast<unsigned>(std::max(1UL, utils::getenv<unsigned long>("RUNAI_STREAMER_INTERNAL_MAX_RESPONSES", 1UL)));
 
         while (completed_chunks < total_chunks)
         {

--- a/cpp/streamer/impl/workload/workload.cc
+++ b/cpp/streamer/impl/workload/workload.cc
@@ -1,14 +1,21 @@
 
 #include "streamer/impl/workload/workload.h"
 
+#include <algorithm>
+#include <map>
 #include <memory>
+#include <optional>
 #include <utility>
+#include <vector>
 
 #include "streamer/impl/s3/s3.h"
 
+#include "common/range/range.h"
 #include "common/response_code/response_code.h"
 #include "common/exception/exception.h"
+#include "common/backend_api/response/response.h"
 
+#include "utils/capacity_queue/capacity_queue.h"
 #include "utils/logging/logging.h"
 
 namespace runai::llm::streamer::impl
@@ -98,9 +105,32 @@ void Workload::assign_global_ids()
     }
 }
 
+namespace
+{
+
+// A single chunk of a task's range, submitted as one ranged read. The owning task is not
+// stored here: it is recovered from request_id via chunk_task_idx (the same map the
+// completion path uses), keeping a single source of truth for the chunk -> task mapping.
+struct ObjectChunk
+{
+    common::backend_api::ObjectRequestId_t request_id;   // unique per chunk
+    size_t offset;                                       // absolute file offset
+    size_t bytesize;                                     // chunk length
+    char * buffer;                                       // destination
+};
+
+} // namespace
+
 void Workload::async_read(std::atomic<bool> & stopped)
 {
     auto response_code = common::ResponseCode::Success;
+
+    // Per-file error for isolated reporting: a task that fails fails only its own file's
+    // batch; other files in the same workload still complete successfully. Populated while
+    // draining and consumed by handle_error() below. A whole-workload abort (stop /
+    // FinishedError / unexpected exception) sets response_code instead and fails every file.
+    std::map<unsigned, common::ResponseCode> error_by_file_index;
+
     try
     {
         assign_global_ids();
@@ -110,18 +140,200 @@ void Workload::async_read(std::atomic<bool> & stopped)
         auto s3_client = std::make_shared<common::s3::S3ClientWrapper>(_batches_by_file_index.begin()->second.object_storage_params);
         _reader = std::make_shared<S3>(s3_client, *config);
 
-        unsigned requested_batches = 0;
-        for (auto & [file_index, batch] : _batches_by_file_index)
+        // Worker-owned scheduling (single thread): split each task's range into chunks and
+        // submit them up to the backend's in-flight window, refilling as completions free
+        // credit. We count chunks: the window is a max in-flight chunk count (the plugin's
+        // byte window / chunk size), each in-flight chunk costs 1, and a task is complete
+        // when its expected number of chunks has finished. Only this thread touches the
+        // queue and the per-task counters, so no locking / atomics are needed.
+        const size_t chunk_bytesize = std::max(static_cast<size_t>(1), config->s3_block_bytesize);
+        const size_t unbounded = static_cast<size_t>(-1);
+        const size_t window_bytes = _reader->max_inflight_bytes();
+        const size_t window_chunks = (window_bytes == unbounded)
+            ? unbounded
+            : std::max(static_cast<size_t>(1), window_bytes / chunk_bytesize);
+
+        utils::CapacityQueue<ObjectChunk> queue(window_chunks);
+
+        // per-task bookkeeping, indexed by task index (global_id - base); touched only by
+        // this thread. task_error holds the first failing chunk's code for the task (Success
+        // while all its chunks have succeeded). task_batch is the batch that owns the task,
+        // so completion handling never has to look a task up by request->file_index.
+        std::vector<unsigned> task_remaining_chunks(_total_tasks, 0);
+        std::vector<Batch *> task_batch(_total_tasks, nullptr);
+        std::vector<common::ResponseCode> task_error(_total_tasks, common::ResponseCode::Success);
+
+        // count chunks up front so we can reserve one contiguous block of request ids and map
+        // each id back to its task with a flat vector (id - chunk_id_base) instead of a hash map
+        size_t total_chunks = 0;
+        for (const auto & [file_index, batch] : _batches_by_file_index)
         {
-            _error_by_file_index[file_index] = handle_batch(file_index, batch, stopped);
-            requested_batches += (_error_by_file_index[file_index] == common::ResponseCode::Success ? 1 : 0);
+            for (const auto & task : batch.tasks)
+            {
+                if (task.info.bytesize != 0)
+                {
+                    total_chunks += (task.info.bytesize + chunk_bytesize - 1) / chunk_bytesize;   // ceil
+                }
+            }
         }
 
-        // wait for all the batched to finish
-        if (requested_batches > 0)
+        // Reserve one contiguous block of request ids for this workload's chunks. assign_global_ids
+        // already advanced the counter past this workload's task ids, so when total_chunks > 0 the
+        // counter is >= 1 here and chunk_id_base >= 1: request id 0 is never a valid chunk id. That
+        // keeps handle 0 reserved for the drained-responder FinishedError sentinel (see the drain
+        // loop below), so a sentinel can never be mistaken for a real completion.
+        const auto chunk_id_base = _async_handle_counter.fetch_add(total_chunks);
+        std::vector<size_t> chunk_task_idx(total_chunks);   // request id (- base) -> owning task index
+
+        size_t next_chunk = 0;
+        for (auto & [file_index, batch] : _batches_by_file_index)
         {
-            LOG(DEBUG) << "Waiting for responses";
-            wait_for_responses(stopped);
+            for (const auto & task : batch.tasks)
+            {
+                if (task.info.bytesize == 0)
+                {
+                    // zero-size task: no backend request, complete immediately
+                    common::backend_api::Response resp(task.info.global_id, common::ResponseCode::Success);
+                    batch.handle_response(resp, &task);
+                    continue;
+                }
+
+                const size_t idx = task.info.global_id - _global_id_base;
+                task_batch[idx] = &batch;
+                size_t offset = task.info.offset;
+                size_t remaining = task.info.bytesize;
+                char * buffer = task.destination();
+                while (remaining > 0)
+                {
+                    const size_t bs = std::min(remaining, chunk_bytesize);   // last chunk is the remainder
+                    // each chunk carries its own unique request id (the backend requires unique
+                    // ids per in-flight request); the flat vector maps it back to the owning task
+                    const auto chunk_id = chunk_id_base + next_chunk;
+                    chunk_task_idx[next_chunk] = idx;
+                    queue.enqueue(ObjectChunk{chunk_id, offset, bs, buffer}, 1);   // cost 1: count chunks
+                    offset += bs;
+                    buffer += bs;
+                    remaining -= bs;
+                    ++task_remaining_chunks[idx];
+                    ++next_chunk;
+                }
+            }
+        }
+
+        // Account for one completed chunk of task idx, whether it came back from the backend or
+        // was short-circuited without a read. Frees the window slot, records the task's first
+        // error, and once all of the task's chunks are done reports its aggregate result. Called
+        // only from this worker thread (the drain loop and submit's short-circuit), so the two
+        // completion paths share a single authority and cannot drift.
+        size_t completed_chunks = 0;
+        auto complete_chunk = [&](size_t idx, common::ResponseCode ret)
+        {
+            ASSERT(_tasks[idx] != nullptr) << "Completing a chunk of a null task at index " << idx;
+            ASSERT(task_remaining_chunks[idx] > 0) << "Chunk completion for task " << _tasks[idx]->info.global_id << " with no remaining chunks";
+
+            queue.complete(1);   // free the window slot so the next chunk can be submitted
+
+            if (ret != common::ResponseCode::Success && task_error[idx] == common::ResponseCode::Success)
+            {
+                task_error[idx] = ret;   // first failing chunk wins for this task
+            }
+
+            // once every chunk of the task has completed, report its aggregate result: success
+            // goes through handle_response; a failure is recorded per file and the task is left
+            // unfinished so handle_error() below fails it (handle_response throws on non-success)
+            if (--task_remaining_chunks[idx] == 0)
+            {
+                if (task_error[idx] == common::ResponseCode::Success)
+                {
+                    common::backend_api::Response task_resp(_tasks[idx]->info.global_id, common::ResponseCode::Success);
+                    task_batch[idx]->handle_response(task_resp, _tasks[idx]);
+                }
+                else
+                {
+                    error_by_file_index.emplace(task_batch[idx]->file_index, task_error[idx]);   // first error per file
+                }
+            }
+
+            ++completed_chunks;
+        };
+
+        auto submit = [&](const ObjectChunk & c)
+        {
+            // request ids are the contiguous block [chunk_id_base, chunk_id_base + total_chunks)
+            ASSERT(c.request_id >= chunk_id_base && c.request_id - chunk_id_base < total_chunks)
+                << "Chunk request id " << c.request_id << " outside [" << chunk_id_base << ", " << (chunk_id_base + total_chunks) << ")";
+            const size_t idx = chunk_task_idx[c.request_id - chunk_id_base];   // owning task
+
+            // the owning task has already failed a chunk: don't waste a backend read on a doomed
+            // task. account for this chunk as completed now (with the task's error). chunks that
+            // were already issued before the failure still land and are handled by the drain loop.
+            if (task_error[idx] != common::ResponseCode::Success)
+            {
+                complete_chunk(idx, task_error[idx]);
+                return;
+            }
+
+            const common::Range range(c.offset, c.bytesize);
+            _reader->async_read(task_batch[idx]->object_storage_params, c.request_id, range, c.buffer);
+        };
+
+        auto pump = [&]()
+        {
+            while (auto c = queue.try_take())
+            {
+                submit(*c);
+            }
+        };
+
+        // prime the window, then refill as completions free credit
+        pump();
+
+        // request completions in batches; the reader may return several ready completions per
+        // call (max_responses > 1), each handled independently below
+        const unsigned max_responses = 64;
+
+        while (completed_chunks < total_chunks)
+        {
+            if (stopped)
+            {
+                throw common::Exception(common::ResponseCode::FinishedError);
+            }
+
+            std::vector<common::backend_api::Response> responses;
+            auto r = _reader->async_response(responses, max_responses);
+            if (r == common::ResponseCode::FinishedError)
+            {
+                throw common::Exception(common::ResponseCode::FinishedError);
+            }
+
+            const size_t completed_before = completed_chunks;
+            for (const auto & response : responses)
+            {
+                // Some plugins (azure/gcs) drain their per-client responder up to max_responses
+                // and append an "empty" FinishedError event (handle 0) once it runs dry, to
+                // signal there is nothing more to hand out this round. It is not a real chunk
+                // completion - stop consuming the batch here.
+                if (response.ret == common::ResponseCode::FinishedError)
+                {
+                    break;
+                }
+
+                const size_t rel = response.handle - chunk_id_base;
+                ASSERT(rel < total_chunks) << "Received response with unknown handle " << response.handle;
+                complete_chunk(chunk_task_idx[rel], response.ret);
+            }
+
+            // refill the window; this can also short-circuit doomed chunks, which advances
+            // completed_chunks without a backend read
+            pump();
+
+            // no completion of any kind this round (only the drained/stopped sentinel) while
+            // chunks remain means the responder was stopped or drained early: abort rather than
+            // spin re-reading the same sentinel
+            if (completed_chunks == completed_before && completed_chunks < total_chunks)
+            {
+                throw common::Exception(common::ResponseCode::FinishedError);
+            }
         }
     }
     catch(const common::Exception & e)
@@ -140,88 +352,19 @@ void Workload::async_read(std::atomic<bool> & stopped)
 
     for (auto & [file_index, batch] : _batches_by_file_index)
     {
+        // whole-workload abort fails every file; otherwise fail only files with a recorded
+        // error (handle_error(Success) is a no-op for files whose tasks all completed)
         auto error_code = response_code;
         if (error_code == common::ResponseCode::Success)
         {
-            ASSERT(_error_by_file_index.find(file_index) != _error_by_file_index.end()) << "Error by file index " << file_index << " not found";
-            error_code = _error_by_file_index.at(file_index);
+            auto it = error_by_file_index.find(file_index);
+            if (it != error_by_file_index.end())
+            {
+                error_code = it->second;
+            }
         }
-
         batch.handle_error(error_code);
     }
-}
-
-common::ResponseCode Workload::handle_batch(unsigned file_index, Batch & batch, std::atomic<bool> & stopped)
-{
-    LOG(SPAM) << "Requesting batch " << batch;
-    auto batch_response_code = common::ResponseCode::Success;
-
-    try
-    {
-        batch.request(_reader, stopped);
-    }
-    catch(const common::Exception & e)
-    {
-        LOG(ERROR) << "Error " << e.error() << " while requesting batch " << batch;
-        batch_response_code = e.error();
-    }
-    catch (...)
-    {
-        LOG(ERROR) << "Unknown error while requesting batch " << batch;
-        batch_response_code = common::ResponseCode::UnknownError;
-    }
-
-    return batch_response_code;
-}
-
-void Workload::wait_for_responses(std::atomic<bool> & stopped)
-{
-    if (stopped)
-    {
-        LOG(DEBUG) << "Terminated while waiting for responses";
-        throw common::Exception(common::ResponseCode::FinishedError);
-    }
-
-    // wait for responses from the reader
-    // stopped flag was propagated to the storage backend when the request was made, and the storage backend is responsible for returning FinishedError when stopped flag is set
-    while (true)
-    {
-        std::vector<common::backend_api::Response> responses;
-        auto r = _reader->async_response(responses, 1);
-        if (r == common::ResponseCode::FinishedError)
-        {
-            LOG(DEBUG) << "FinishedError while waiting for responses";
-            throw common::Exception(common::ResponseCode::FinishedError);
-        }
-
-        const auto & response = responses.back();
-
-        if (response.ret == common::ResponseCode::FinishedError)
-        {
-            LOG(DEBUG) << "FinishedError while waiting for responses";
-            throw common::Exception(common::ResponseCode::FinishedError);
-        }
-
-        ASSERT(response.handle >= _global_id_base) << "Received response with invalid handle " << response.handle << " expected at least " << _global_id_base;
-
-        auto index = response.handle - _global_id_base;
-        ASSERT(index < _tasks.size()) << "Received response with invalid handle " << response.handle << " expected at most " << _global_id_base + _tasks.size();
-
-        const Task * task_ptr = _tasks[index];
-        ASSERT(task_ptr != nullptr) << "Received response from a null task ; response: " << response;
-
-        auto file_index = task_ptr->request->file_index;
-        auto & batch = _batches_by_file_index.at(file_index);
-
-        if (response.ret != common::ResponseCode::Success)
-        {
-            _error_by_file_index.at(file_index) = response.ret;
-        }
-
-        batch.handle_response(response, task_ptr);
-    }
-
-    LOG(DEBUG) << "Finished reading files "  << (stopped ? " - terminated" : " successfully");
 }
 
 }; // namespace runai::llm::streamer::impl

--- a/cpp/streamer/impl/workload/workload.cc
+++ b/cpp/streamer/impl/workload/workload.cc
@@ -321,8 +321,16 @@ void Workload::async_read(std::atomic<bool> & stopped)
                     break;
                 }
 
+                // Hard range check before the (unsigned) subtraction: a stale/cancelled
+                // completion or a buggy backend could deliver a handle outside this workload's
+                // reserved block. Guarding here (not just via ASSERT, which is stripped in
+                // release builds) prevents an out-of-bounds read of chunk_task_idx.
+                if (response.handle < chunk_id_base || response.handle - chunk_id_base >= total_chunks)
+                {
+                    LOG(ERROR) << "Received response with out-of-range handle " << response.handle;
+                    throw common::Exception(common::ResponseCode::UnknownError);
+                }
                 const size_t rel = response.handle - chunk_id_base;
-                ASSERT(rel < total_chunks) << "Received response with unknown handle " << response.handle;
                 complete_chunk(chunk_task_idx[rel], response.ret);
             }
 

--- a/cpp/streamer/impl/workload/workload.h
+++ b/cpp/streamer/impl/workload/workload.h
@@ -30,13 +30,10 @@ struct Workload
 
  private:
     common::ResponseCode verify_batch(const Batch & batch);
-    void wait_for_responses(std::atomic<bool> & stopped);
     void async_read(std::atomic<bool> & stopped);
-    common::ResponseCode handle_batch(unsigned file_index, Batch & batch, std::atomic<bool> & stopped);
     void assign_global_ids();
  private:
     std::map<unsigned, Batch> _batches_by_file_index;
-    std::map<unsigned, common::ResponseCode> _error_by_file_index;
     bool _is_object_storage = false;
     std::shared_ptr<Reader> _reader;
     size_t _total_tasks = 0;

--- a/cpp/streamer/streamer_s3_test.cc
+++ b/cpp/streamer/streamer_s3_test.cc
@@ -179,6 +179,247 @@ TEST_F(StreamerTest, Async_Read)
     EXPECT_EQ(verify_mock(), 0);
 }
 
+TEST_F(StreamerTest, Async_Read_Bounded_By_Window)
+{
+    utils::Dylib dylib("libstreamers3.so");
+    auto mock_cleanup = dylib.dlsym<void(*)()>("runai_mock_s3_cleanup");
+    auto verify_mock = dylib.dlsym<int(*)(void)>("runai_mock_s3_clients");
+    auto set_window = dylib.dlsym<void(*)(size_t)>("runai_mock_s3_set_inflight_window");
+    auto max_concurrent = dylib.dlsym<size_t(*)()>("runai_mock_s3_max_concurrent");
+
+    // Bound the in-flight window. The effective chunk size is clamped to the 5 MiB S3
+    // minimum, so the per-client window is at most window_bytes / 5 MiB chunks.
+    const size_t min_chunk = 5 * 1024 * 1024;
+    const size_t window_chunks = 5;
+    set_window(window_chunks * min_chunk);
+
+    void * streamer;
+    ASSERT_EQ(runai_start(&streamer), static_cast<int>(common::ResponseCode::Success));
+
+    auto res = runai_request(streamer,
+                    num_files,
+                    file_names.data(),
+                    file_offsets.data(),
+                    sizes.data(),
+                    dsts.data(),
+                    num_ranges.data(),
+                    internal_sizes.data(),
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    nullptr);
+    EXPECT_EQ(res, static_cast<int>(common::ResponseCode::Success));
+
+    // every sub-request still completes successfully under the bounded window
+    unsigned r;
+    unsigned file_index;
+    for (unsigned i = 0; i < num_expected_responses; ++i)
+    {
+        r = utils::random::number();
+        file_index = utils::random::number();
+        auto response_code = runai_response(streamer, &file_index, &r);
+        EXPECT_EQ(response_code, static_cast<int>(common::ResponseCode::Success));
+        if (response_code != static_cast<int>(common::ResponseCode::Success))
+        {
+            break;
+        }
+        EXPECT_LT(file_index, num_files);
+        EXPECT_EQ(expected_response[file_index].count(r), 1);
+        expected_response[file_index].erase(r);
+    }
+
+    // the per-client in-flight never exceeded the configured window (windowing is enforced),
+    // and the window was actually exercised (something was in flight)
+    const size_t peak = max_concurrent();
+    EXPECT_LE(peak, window_chunks);
+    EXPECT_GT(peak, 0u);
+
+    runai_end(streamer);
+    mock_cleanup();
+    EXPECT_EQ(verify_mock(), 0);
+}
+
+TEST_F(StreamerTest, Async_Read_Per_File_Error_Isolation)
+{
+    if (num_files < 2)
+    {
+        GTEST_SKIP() << "needs at least two files to observe per-file isolation";
+    }
+
+    utils::Dylib dylib("libstreamers3.so");
+    auto mock_cleanup = dylib.dlsym<void(*)()>("runai_mock_s3_cleanup");
+    auto verify_mock = dylib.dlsym<int(*)(void)>("runai_mock_s3_clients");
+    auto set_failing_path = dylib.dlsym<void(*)(const char*)>("runai_mock_s3_set_failing_path");
+
+    // fail every read of file 0 (its object key is unique); all other files must still succeed
+    const unsigned failing_file = 0;
+    set_failing_path(s3_paths[failing_file].c_str());
+
+    void * streamer;
+    ASSERT_EQ(runai_start(&streamer), static_cast<int>(common::ResponseCode::Success));
+
+    auto res = runai_request(streamer,
+                    num_files,
+                    file_names.data(),
+                    file_offsets.data(),
+                    sizes.data(),
+                    dsts.data(),
+                    num_ranges.data(),
+                    internal_sizes.data(),
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    nullptr);
+    EXPECT_EQ(res, static_cast<int>(common::ResponseCode::Success));
+
+    unsigned failed = 0;
+    unsigned succeeded = 0;
+    for (unsigned i = 0; i < num_expected_responses; ++i)
+    {
+        unsigned r = utils::random::number();
+        unsigned file_index = utils::random::number();
+        auto response_code = runai_response(streamer, &file_index, &r);
+        ASSERT_LT(file_index, num_files);
+
+        if (file_index == failing_file)
+        {
+            // the failing file's ranges report the error - isolated to this file
+            EXPECT_EQ(response_code, static_cast<int>(common::ResponseCode::FileAccessError));
+            ++failed;
+        }
+        else
+        {
+            // every other file completes successfully with its expected range indices
+            EXPECT_EQ(response_code, static_cast<int>(common::ResponseCode::Success));
+            EXPECT_EQ(expected_response[file_index].count(r), 1);
+            expected_response[file_index].erase(r);
+            ++succeeded;
+        }
+    }
+
+    // exactly the failing file's ranges failed; all other files' ranges succeeded
+    EXPECT_EQ(failed, num_ranges[failing_file]);
+    EXPECT_EQ(succeeded, num_expected_responses - num_ranges[failing_file]);
+    for (unsigned i = 0; i < num_files; ++i)
+    {
+        if (i != failing_file)
+        {
+            EXPECT_TRUE(expected_response[i].empty());
+        }
+    }
+
+    runai_end(streamer);
+    mock_cleanup();
+    EXPECT_EQ(verify_mock(), 0);
+}
+
+TEST_F(StreamerTest, Async_Read_Batched_Completions)
+{
+    utils::Dylib dylib("libstreamers3.so");
+    auto mock_cleanup = dylib.dlsym<void(*)()>("runai_mock_s3_cleanup");
+    auto verify_mock = dylib.dlsym<int(*)(void)>("runai_mock_s3_clients");
+    auto max_events_per_wait = dylib.dlsym<size_t(*)()>("runai_mock_s3_max_events_per_wait");
+
+    // default mock window is unbounded, so every chunk is in flight before the first wait and
+    // a single obj_wait_for_completions returns many completions - exercising max_responses > 1
+    void * streamer;
+    ASSERT_EQ(runai_start(&streamer), static_cast<int>(common::ResponseCode::Success));
+
+    auto res = runai_request(streamer,
+                    num_files,
+                    file_names.data(),
+                    file_offsets.data(),
+                    sizes.data(),
+                    dsts.data(),
+                    num_ranges.data(),
+                    internal_sizes.data(),
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    nullptr);
+    EXPECT_EQ(res, static_cast<int>(common::ResponseCode::Success));
+
+    // every sub-request still completes successfully when completions are drained in batches
+    for (unsigned i = 0; i < num_expected_responses; ++i)
+    {
+        unsigned r = utils::random::number();
+        unsigned file_index = utils::random::number();
+        auto response_code = runai_response(streamer, &file_index, &r);
+        EXPECT_EQ(response_code, static_cast<int>(common::ResponseCode::Success));
+        if (response_code != static_cast<int>(common::ResponseCode::Success))
+        {
+            break;
+        }
+        EXPECT_LT(file_index, num_files);
+        EXPECT_EQ(expected_response[file_index].count(r), 1);
+        expected_response[file_index].erase(r);
+    }
+
+    // at least one wait returned more than one completion (batch drain was actually exercised)
+    EXPECT_GT(max_events_per_wait(), 1u);
+
+    runai_end(streamer);
+    mock_cleanup();
+    EXPECT_EQ(verify_mock(), 0);
+}
+
+TEST_F(StreamerTest, Async_Read_Tolerates_Finished_Sentinel)
+{
+    utils::Dylib dylib("libstreamers3.so");
+    auto mock_cleanup = dylib.dlsym<void(*)()>("runai_mock_s3_cleanup");
+    auto verify_mock = dylib.dlsym<int(*)(void)>("runai_mock_s3_clients");
+    auto set_append_sentinel = dylib.dlsym<void(*)(bool)>("runai_mock_s3_set_append_finished_sentinel");
+
+    // mimic azure/gcs: obj_wait_for_completions appends a FinishedError sentinel (handle 0)
+    // once the ready completions drain. The worker must skip it, not fail on the 0 handle.
+    set_append_sentinel(true);
+
+    void * streamer;
+    ASSERT_EQ(runai_start(&streamer), static_cast<int>(common::ResponseCode::Success));
+
+    auto res = runai_request(streamer,
+                    num_files,
+                    file_names.data(),
+                    file_offsets.data(),
+                    sizes.data(),
+                    dsts.data(),
+                    num_ranges.data(),
+                    internal_sizes.data(),
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    nullptr);
+    EXPECT_EQ(res, static_cast<int>(common::ResponseCode::Success));
+
+    // every sub-request still completes successfully despite the interleaved sentinel events
+    for (unsigned i = 0; i < num_expected_responses; ++i)
+    {
+        unsigned r = utils::random::number();
+        unsigned file_index = utils::random::number();
+        auto response_code = runai_response(streamer, &file_index, &r);
+        EXPECT_EQ(response_code, static_cast<int>(common::ResponseCode::Success));
+        if (response_code != static_cast<int>(common::ResponseCode::Success))
+        {
+            break;
+        }
+        EXPECT_LT(file_index, num_files);
+        EXPECT_EQ(expected_response[file_index].count(r), 1);
+        expected_response[file_index].erase(r);
+    }
+    for (unsigned i = 0; i < num_files; ++i)
+    {
+        EXPECT_TRUE(expected_response[i].empty());
+    }
+
+    runai_end(streamer);
+    mock_cleanup();
+    EXPECT_EQ(verify_mock(), 0);
+}
+
 TEST_F(StreamerTest, Increase_Insufficient_Fd_Limit)
 {
     utils::Dylib dylib("libstreamers3.so");

--- a/cpp/streamer/streamer_s3_test.cc
+++ b/cpp/streamer/streamer_s3_test.cc
@@ -322,8 +322,11 @@ TEST_F(StreamerTest, Async_Read_Batched_Completions)
     auto verify_mock = dylib.dlsym<int(*)(void)>("runai_mock_s3_clients");
     auto max_events_per_wait = dylib.dlsym<size_t(*)()>("runai_mock_s3_max_events_per_wait");
 
-    // default mock window is unbounded, so every chunk is in flight before the first wait and
-    // a single obj_wait_for_completions returns many completions - exercising max_responses > 1
+    // raise the internal batch size so the worker requests many completions per wait (the
+    // production default is 1); the mock's window is unbounded, so every chunk is in flight
+    // before the first wait and a single obj_wait_for_completions returns many completions
+    utils::temp::Env max_responses("RUNAI_STREAMER_INTERNAL_MAX_RESPONSES", 64UL);
+
     void * streamer;
     ASSERT_EQ(runai_start(&streamer), static_cast<int>(common::ResponseCode::Success));
 
@@ -372,6 +375,11 @@ TEST_F(StreamerTest, Async_Read_Tolerates_Finished_Sentinel)
     auto mock_cleanup = dylib.dlsym<void(*)()>("runai_mock_s3_cleanup");
     auto verify_mock = dylib.dlsym<int(*)(void)>("runai_mock_s3_clients");
     auto set_append_sentinel = dylib.dlsym<void(*)(bool)>("runai_mock_s3_set_append_finished_sentinel");
+
+    // raise the internal batch size (>1) so obj_wait_for_completions has room to append the
+    // sentinel after the ready completions - at the production default of 1 the buffer is full
+    // after one real event and the sentinel path would never be exercised
+    utils::temp::Env max_responses("RUNAI_STREAMER_INTERNAL_MAX_RESPONSES", 64UL);
 
     // mimic azure/gcs: obj_wait_for_completions appends a FinishedError sentinel (handle 0)
     // once the ready completions drain. The worker must skip it, not fail on the 0 handle.

--- a/cpp/utils/capacity_queue/BUILD
+++ b/cpp/utils/capacity_queue/BUILD
@@ -1,0 +1,13 @@
+load("//:rules.bzl", "runai_cc_auto_library", "runai_cc_test")
+
+runai_cc_auto_library(
+    name = "capacity_queue",
+)
+
+runai_cc_test(
+    name = "capacity_queue_test",
+    srcs = ["capacity_queue_test.cc"],
+    deps = [
+        ":capacity_queue",
+    ],
+)

--- a/cpp/utils/capacity_queue/capacity_queue.h
+++ b/cpp/utils/capacity_queue/capacity_queue.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <optional>
+#include <utility>
+
+namespace runai::llm::streamer::utils
+{
+
+// CapacityQueue - a credit-bounded pending queue.
+//
+// Holds items that are waiting to be submitted and bounds how much "work" may be
+// in flight at once. The owner submits items by calling try_take() (which reserves
+// the item's cost against the capacity) and releases credit by calling complete()
+// when an item finishes, which lets the next pending item become takeable.
+//
+// cost and capacity are in caller-defined units: bytes for the S3 in-flight window
+// (bandwidth-delay product), or an operation count for threadpool-bounded backends.
+//
+// NOT THREAD SAFE - by design. It is meant to be owned by a single worker that
+// enqueues, takes and completes on one thread; the cross-thread completion signal
+// (e.g. an async callback) is delivered through a separate thread-safe queue, and
+// the worker calls complete() from its own loop. Keeping this object single-owner
+// makes it a deterministic, independently testable unit.
+template <typename T>
+class CapacityQueue
+{
+ public:
+    explicit CapacityQueue(size_t capacity) :
+        _capacity(capacity)
+    {}
+
+    // Add an item to be submitted later.
+    // cost     - the amount of capacity this item consumes while in flight.
+    // priority - reserved for later priority scheduling; ignored by the current
+    //            FIFO selection (0 = default).
+    void enqueue(T item, size_t cost, unsigned priority = 0)
+    {
+        _pending.push_back(Entry{std::move(item), cost, priority});
+    }
+
+    // Return the next item to submit and reserve its cost against the capacity, or
+    // std::nullopt if the window is currently full.
+    //
+    // When nothing is in flight, one item is always returned even if its cost
+    // exceeds the whole capacity - otherwise an item larger than the window could
+    // never be submitted (deadlock).
+    std::optional<T> try_take()
+    {
+        if (_pending.empty())
+        {
+            return std::nullopt;
+        }
+
+        // Selection point: FIFO today. To add priorities, replace _pending with
+        // per-priority buckets and pick the highest-priority non-empty bucket here;
+        // nothing else in this class needs to change.
+        const size_t cost = _pending.front().cost;
+
+        if (_inflight != 0 && _inflight + cost > _capacity)
+        {
+            return std::nullopt;
+        }
+
+        Entry entry = std::move(_pending.front());
+        _pending.pop_front();
+        _inflight += entry.cost;
+        return std::optional<T>(std::move(entry.item));
+    }
+
+    // Release the credit previously reserved for a completed item. Pass the same
+    // cost that try_take() reserved for it. Clamps at zero defensively.
+    void complete(size_t cost)
+    {
+        _inflight = (_inflight >= cost) ? _inflight - cost : 0;
+    }
+
+    // no items left to submit (some may still be in flight)
+    bool empty() const
+    {
+        return _pending.empty();
+    }
+
+    // nothing left to submit and nothing in flight
+    bool idle() const
+    {
+        return _pending.empty() && _inflight == 0;
+    }
+
+    size_t inflight() const
+    {
+        return _inflight;
+    }
+
+    size_t pending() const
+    {
+        return _pending.size();
+    }
+
+    size_t capacity() const
+    {
+        return _capacity;
+    }
+
+ private:
+    struct Entry
+    {
+        T item;
+        size_t cost;
+        unsigned priority;
+    };
+
+    size_t _capacity;
+    size_t _inflight = 0;
+    std::deque<Entry> _pending;   // FIFO; see the selection point in try_take()
+};
+
+} // namespace runai::llm::streamer::utils

--- a/cpp/utils/capacity_queue/capacity_queue_test.cc
+++ b/cpp/utils/capacity_queue/capacity_queue_test.cc
@@ -1,0 +1,155 @@
+#include "utils/capacity_queue/capacity_queue.h"
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <vector>
+
+namespace runai::llm::streamer::utils
+{
+
+TEST(CapacityQueue, EmptyIsIdleAndTakesNothing)
+{
+    CapacityQueue<int> q(100);
+
+    EXPECT_TRUE(q.empty());
+    EXPECT_TRUE(q.idle());
+    EXPECT_EQ(q.pending(), 0U);
+    EXPECT_EQ(q.inflight(), 0U);
+    EXPECT_FALSE(q.try_take().has_value());
+}
+
+TEST(CapacityQueue, TakesUntilWindowFull)
+{
+    CapacityQueue<int> q(100);
+    q.enqueue(1, 40);
+    q.enqueue(2, 40);
+    q.enqueue(3, 40);
+
+    EXPECT_EQ(q.pending(), 3U);
+
+    auto a = q.try_take();          // inflight 0 -> 40
+    ASSERT_TRUE(a.has_value());
+    EXPECT_EQ(*a, 1);
+    EXPECT_EQ(q.inflight(), 40U);
+
+    auto b = q.try_take();          // 40 + 40 = 80 <= 100
+    ASSERT_TRUE(b.has_value());
+    EXPECT_EQ(*b, 2);
+    EXPECT_EQ(q.inflight(), 80U);
+
+    auto c = q.try_take();          // 80 + 40 = 120 > 100 -> blocked
+    EXPECT_FALSE(c.has_value());
+    EXPECT_EQ(q.inflight(), 80U);
+    EXPECT_EQ(q.pending(), 1U);
+}
+
+TEST(CapacityQueue, CompleteFreesCredit)
+{
+    CapacityQueue<int> q(100);
+    q.enqueue(1, 40);
+    q.enqueue(2, 40);
+    q.enqueue(3, 40);
+
+    ASSERT_TRUE(q.try_take().has_value());   // inflight 40
+    ASSERT_TRUE(q.try_take().has_value());   // inflight 80
+    ASSERT_FALSE(q.try_take().has_value());  // full
+
+    q.complete(40);                          // inflight 40
+    EXPECT_EQ(q.inflight(), 40U);
+
+    auto c = q.try_take();                   // 40 + 40 = 80 <= 100
+    ASSERT_TRUE(c.has_value());
+    EXPECT_EQ(*c, 3);
+    EXPECT_EQ(q.inflight(), 80U);
+}
+
+TEST(CapacityQueue, AlwaysTakesOneWhenIdleEvenIfOverCapacity)
+{
+    CapacityQueue<int> q(10);
+    q.enqueue(1, 1000);   // larger than the whole window
+    q.enqueue(2, 5);
+
+    auto a = q.try_take();   // inflight 0 -> allowed despite cost > capacity
+    ASSERT_TRUE(a.has_value());
+    EXPECT_EQ(*a, 1);
+    EXPECT_EQ(q.inflight(), 1000U);
+
+    // now something is in flight, so the next item must wait
+    EXPECT_FALSE(q.try_take().has_value());
+
+    q.complete(1000);
+    auto b = q.try_take();
+    ASSERT_TRUE(b.has_value());
+    EXPECT_EQ(*b, 2);
+}
+
+TEST(CapacityQueue, PreservesFifoOrder)
+{
+    CapacityQueue<int> q(1000);
+    for (int i = 0; i < 5; ++i)
+    {
+        q.enqueue(i, 1);
+    }
+    for (int i = 0; i < 5; ++i)
+    {
+        auto v = q.try_take();
+        ASSERT_TRUE(v.has_value());
+        EXPECT_EQ(*v, i);
+    }
+    EXPECT_TRUE(q.empty());
+}
+
+TEST(CapacityQueue, CompleteClampsAtZero)
+{
+    CapacityQueue<int> q(100);
+    q.enqueue(1, 30);
+    ASSERT_TRUE(q.try_take().has_value());   // inflight 30
+    q.complete(1000);                        // over-complete
+    EXPECT_EQ(q.inflight(), 0U);
+    EXPECT_TRUE(q.idle());
+}
+
+TEST(CapacityQueue, CompletionDrivenDrainNeverExceedsCapacity)
+{
+    constexpr size_t capacity = 100;
+    constexpr size_t cost = 30;
+    constexpr int total = 10;
+
+    CapacityQueue<int> q(capacity);
+    for (int i = 0; i < total; ++i)
+    {
+        q.enqueue(i, cost);
+    }
+
+    std::vector<int> taken;
+    int completed = 0;
+
+    auto pump = [&]
+    {
+        while (auto v = q.try_take())
+        {
+            taken.push_back(*v);
+            EXPECT_LE(q.inflight(), capacity);   // costs are <= capacity, so never exceeded
+        }
+    };
+
+    pump();
+    while (completed < total)
+    {
+        ASSERT_GT(q.inflight(), 0U);   // something must be in flight to complete
+        q.complete(cost);
+        ++completed;
+        pump();
+    }
+
+    // everything drained, in FIFO order, and the queue is idle
+    ASSERT_EQ(static_cast<int>(taken.size()), total);
+    for (int i = 0; i < total; ++i)
+    {
+        EXPECT_EQ(taken[i], i);
+    }
+    EXPECT_TRUE(q.idle());
+}
+
+} // namespace runai::llm::streamer::utils


### PR DESCRIPTION
## Capacity-controlled streaming from object storage

Adds per-client submission throttling to the object-storage read path so a worker no longer fires every chunk at the cloud SDK at once, but keeps a bounded number of chunks in flight and refills as completions arrive.

- **In-flight window per backend.** 
  - Each plugin advertises a max in-flight byte budget via a new `obj_get_backend_config("max_inflight_bytes")` call 
  - S3 derives a bandwidth-delay product from its target throughput;
  - GCS/Azure use their thread-pool capacity.
  - A shared headroom margin  (`RUNAI_STREAMER_INFLIGHT_WINDOW_MARGIN`, default 1.5) keeps the backend busy during refill.

- **Worker-owned chunk scheduler.** `Workload` splits each task's range into chunks and submits them through a new, unit-tested `CapacityQueue` (credit-bounded, single-owner, with a FIFO→priority seam for later). The S3 client is thinned to one ranged GET per chunk.
- **Per-file error isolation.** A read failure now fails only its own file; other files in the same request still complete. Doomed chunks of a failed task are short-circuited instead of read.
- **Completion draining.** Handles batched completions and tolerates the drained-responder sentinel
  emitted by the GCS/Azure plugins; refill batch size is tunable via `RUNAI_STREAMER_INTERNAL_MAX_RESPONSES`
  (default 1).

Fully backward compatible — backends that don't advertise a window fall back to unbounded (previous
behavior). Adds `CapacityQueue` unit tests and streamer tests for windowing, per-file isolation,
batched completions, and sentinel tolerance; removes now-dead `Batch` request paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added backend config key `max_inflight_bytes` (Azure/GCS/S3) to advertise an in-flight submission budget; exposed via the reader layer to throttle streaming.
  * Added `inflight_window_margin` env override and introduced capacity-credited chunk scheduling to drive async range reads.

* **Bug Fixes**
  * Improved range-read correctness by reporting truncation on unexpected byte counts.
  * Strengthened per-file error isolation so failures don’t impact other concurrent files.

* **Tests**
  * Expanded streamer tests and S3 mock controls for bounded concurrency, batched completion draining, and finished-sentinel tolerance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->