### PR TITLE
Fix: skip empty files in next_request instead of terminating the stream

### DIFF
--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/requests_iterator.py
@@ -152,10 +152,20 @@ class FilesRequestsIterator:
             file_chunks = file_chunks_iterator.next_chunks(
                 self.memory_limit - current_request_memory_size
             )
-            if file_chunks_iterator.is_finished():
+            finished = file_chunks_iterator.is_finished()
+            if finished:
                 self.q.popleft()
             
             if len(file_chunks.chunks) == 0 or sum(file_chunks.chunks) == 0:
+                if finished:
+                    # The file itself has no data to stream (e.g. an empty
+                    # safetensors shard): skip it and keep packing from the
+                    # next file. Terminating here would silently drop every
+                    # remaining file in the queue.
+                    continue
+                # The next chunk does not fit into this request's remaining
+                # buffer budget: close this request; the file stays queued
+                # for the next request.
                 break
 
             files_request.append(file_chunks)

--- a/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_requests_iterator.py
+++ b/py/runai_model_streamer/runai_model_streamer/file_streamer/tests/test_requests_iterator.py
@@ -188,6 +188,35 @@ class TestFilesRequestsIterator(unittest.TestCase):
         res = requests_iterator.next_request()
         self.assertIsNone(res)
 
+    def test_next_request_empty_file_first_does_not_terminate(self):
+        requests_iterator = FilesRequestsIterator(
+            100, [FileChunks(17, "empty.txt", 0, []), FileChunks(18, "a.txt", 10, [5])]
+        )
+
+        files_requests = requests_iterator.next_request()
+        self.assertIsNotNone(files_requests)
+        self.assertEqual([f.id for f in files_requests.files], [18])
+        self.assertEqual(files_requests.files[0].chunks, [5])
+
+        self.assertIsNone(requests_iterator.next_request())
+
+    def test_next_request_empty_files_between_data_files(self):
+        requests_iterator = FilesRequestsIterator(
+            100,
+            [
+                FileChunks(17, "a.txt", 10, [1, 2]),
+                FileChunks(18, "empty1.txt", 0, []),
+                FileChunks(19, "empty2.txt", 0, []),
+                FileChunks(20, "b.txt", 10, [3]),
+            ],
+        )
+
+        files_requests = requests_iterator.next_request()
+        self.assertIsNotNone(files_requests)
+        self.assertEqual([f.id for f in files_requests.files], [17, 20])
+
+        self.assertIsNone(requests_iterator.next_request())
+
 class TestFilesRequestsIteratorWithBuffer(unittest.TestCase):
     def test_memory_cap_unlimited(self):
         requests_iterator = FilesRequestsIteratorWithBuffer.with_memory_cap(


### PR DESCRIPTION
Fixes #157

### Problem

`FilesRequestsIterator.next_request()` treats any empty `next_chunks()` result as the end of the current request. When that happens at the head of a *fresh* request — e.g. because the queue-head file is a safetensors shard with **zero tensors** — the resulting empty request is returned as `None`, which the iteration layer interprets as end-of-stream: **every remaining queued file is silently dropped**, with no error or warning.

Real-world impact: checkpoints produced by fixed-shard-count exporters can contain valid empty shards (40-byte files). Depending on directory listing order, vLLM's `--load-format runai_streamer` silently served models with 70–100% of their weights left at initialization values (vllm-project/vllm#38991).

### Fix

Distinguish the two conditions behind an empty `next_chunks()` result, using `is_finished()` which is already evaluated after every call:

- **file finished with no data** (empty shard) → `continue`: skip it and keep packing from the next file;
- **file not finished** (next chunk exceeds the request's remaining buffer budget) → `break` as before: close this request; the file stays queued and is handled by the next request.

### Validation

- Existing unit tests: 18/18 pass unchanged — including `test_file_chunks_zero_chunks` (a single empty file still yields `None`, since after the skip the queue is empty) and `test_next_request_multi_file_block_on_file` (memory-cap request splitting untouched).
- Two new regression tests: empty file first, and empty files between data files.
- The distributed path is unaffected: `partition_by_chunks` already filters `chunk_size > 0` and never emits empty `FileChunks`.
- End-to-end in vLLM on the originally affected checkpoints (10 shards, 8–9 empty): with this fix all shards are requested and every loaded parameter is SHA-256-identical to a `safetensors`-library load (476/476 and 560/560 params, verified on two arm64 platforms).

Note for reviewers: with this change a file consisting solely of zero-**size** tensors is also skipped (its degenerate tensors are not yielded). The previous behavior dropped all subsequent files in that case, and `partition_by_chunks` already treats zero-size chunks as non-work — but flagging it so the intended semantics are chosen consciously.

---
*Investigation and fix developed with [Claude Code](https://claude.com/claude-code) (Claude Fable 5), reviewed by @janbernloehr.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file streaming to continue processing subsequent files when empty files or shards are encountered.
  * Prevented valid data from being dropped after an empty file.

* **Tests**
  * Added coverage for empty files appearing first or between files containing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->