### PR TITLE
Renamed azure cache client package

### DIFF
--- a/cpp/azure/azcache_provider/azcache_provider_loader.cc
+++ b/cpp/azure/azcache_provider/azcache_provider_loader.cc
@@ -21,7 +21,7 @@ namespace
 {
 
 // Known cache provider package/library names for auto-discovery
-constexpr const char* CACHE_PROVIDER_PACKAGE = "py_tachyon_client";
+constexpr const char* CACHE_PROVIDER_PACKAGE = "dacs_client";
 constexpr const char* CACHE_PROVIDER_LIB = "libStorageDirect.so";
 
 /**

--- a/docs/src/env-vars.md
+++ b/docs/src/env-vars.md
@@ -154,7 +154,7 @@ String (e.g. `blob.core.chinacloudapi.cn`, `blob.core.usgovcloudapi.net`)
 
 > **Experimental** — This feature is under active development and may change in future releases.
 
-Controls whether the Azure Blob cache provider is enabled. When a compatible cache provider package (e.g., `tachyon-client`) is installed alongside `runai-model-streamer`, the streamer auto-discovers and loads it at runtime to accelerate model loading from Azure Blob Storage via a distributed cache.
+Controls whether the Azure Blob cache provider is enabled. When a compatible cache provider package (e.g., `dacs-client`) is installed alongside `runai-model-streamer`, the streamer auto-discovers and loads it at runtime to accelerate model loading from Azure Blob Storage via a distributed cache.
 
 Set to `0` to disable the cache provider entirely, even if the package is installed. This is the recommended way to disable caching in case of issues.
 

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -175,7 +175,7 @@ export AZURE_STORAGE_ACCOUNT_NAME="myaccount"
 
 The DefaultAzureCredential chain tries multiple authentication methods in order:
 1. **Environment variables** (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`) - for service principal authentication
-2. **Managed Identity** - no configuration needed when running in Azure (VMs, AKS, App Service, etc.)
+2. **Managed Identity** - recommended when running in Azure (VMs, AKS, App Service, etc.). See [Managed identities for Azure resources](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview)
 3. **Azure CLI** - authenticate via `az login`
 4. **Azure PowerShell** - authenticate via `Connect-AzAccount`
 5. **Azure Developer CLI** - authenticate via `azd auth login`
@@ -217,11 +217,11 @@ export AZURE_STORAGE_SAS_TOKEN="sv=2021-08-06&ss=b&srt=co&sp=rl&se=2026-01-01T00
 
 > **Experimental** — This feature is under active development and may change in future releases.
 
-The streamer supports pluggable cache providers for Azure Blob Storage. When a compatible cache provider package is installed (e.g., `tachyon-client`), it is auto-discovered and loaded at runtime. All blob reads are then routed through the cache provider instead of the Azure SDK, enabling integration with distributed caches to accelerate model loading.
+The streamer supports pluggable cache providers for Azure Blob Storage. When a compatible cache provider package is installed (e.g., `dacs-client`), it is auto-discovered and loaded at runtime. All blob reads are then routed through the cache provider instead of the Azure SDK, enabling integration with distributed caches to accelerate model loading.
 
 ###### How it works
 
-1. Install the cache provider package alongside `runai-model-streamer` (e.g., `pip install tachyon-client`)
+1. Install the cache provider package alongside `runai-model-streamer` (e.g., `pip install dacs-client`)
 2. At startup, the streamer auto-discovers the cache library in Python site-packages via `dladdr`
 3. The library is loaded via `dlopen` and the `blob_read` symbol is resolved
 4. All subsequent Azure blob reads are served through the cache provider
@@ -274,7 +274,7 @@ export RUNAI_STREAMER_LOG_LEVEL=DEBUG
 
 You should see:
 ```text
-AzCacheProvider: auto-discovered cache library: /path/to/site-packages/py_tachyon_client/libStorageDirect.so
+AzCacheProvider: auto-discovered cache library: /path/to/site-packages/dacs_client/libStorageDirect.so
 AzCacheProvider: cache provider loaded successfully from /path/to/...
 ```
 


### PR DESCRIPTION
The existing Python client's import package is renamed to dacs_client. Update the hardcoded package name used for cache auto-discovery so libStorageDirect.so is found again, and refresh the docs to the new pip distribution name (dacs-client).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Azure Blob Cache Provider guidance to use the current `dacs-client` package name.
  * Revised auto-discovery instructions and debugging examples to reflect the updated provider library.
  * Clarified Managed Identity authentication guidance and added a relevant documentation link.

* **Bug Fixes**
  * Improved Azure cache provider auto-discovery compatibility by recognizing the current provider package naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->